### PR TITLE
add getLocal method to find nodes on the same network...

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -37,7 +37,10 @@ var manifest = {
     'follow',
     'unfollow',
     'isFollowing',
-    'setProfile'
+    'setProfile',
+
+    //local nodes
+    'getLocal',
   ],
 
   source: [
@@ -183,6 +186,11 @@ function api (server, config) {
       ssb.feedsLinkedFromFeed(feed.id, 'follows'),
       pull.map(function(link) { return link.dest })
     )
+  }
+
+  api.getLocal = function (_cb, cb) {
+    if(!cb) cb = _cb
+    cb(null, server.localPeers || [])
   }
 
   return api


### PR DESCRIPTION
okay somehow I missed this from the first discovery pull request. it adds getLocal into the api...
hmm, maybe we should leave this out, until plugins are right?
