### PR TITLE
use a default port, and allow seeds to be passed as a string

### DIFF
--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -7,14 +7,26 @@ function all(stream, cb) {
   }
 }
 
+function isString(s) {
+  return 'string' === typeof s
+}
+
+var DEFAULT_PORT = 2000
+
 function peers (server, cb) {
   var config = server.config
 
   var seeds = config.seeds
   seeds =
-    ( isArray(seeds)  ? seeds
-    : isObject(seeds) ? [seeds]
-    : [])
+    (isArray(seeds)  ? seeds : [seeds]).filter(Boolean)
+      .map(function (e) {
+            if(isString(e)) {
+              var parts = e.split(':')
+              e = {host: parts[0], port: parts[1]}
+            }
+            e.port = e.port || DEFAULT_PORT
+            return e
+          })
 
   //local peers added by the local discovery...
   //could have the local plugin call a method to add this,


### PR DESCRIPTION
before, passing seeds in on command line looked like this:

``` js
./client.js server --seeds.host grimwire.com --seeds.port 2000
```

but this pull request simplifies to

``` js
./client.js server --seeds grimwire.com:2000
```

Also, you can leave off the default port

``` js
./client.js server --seeds grimwire.com
```

if you have more than one seed server, it is like this:

``` js
./client.js server --seeds grimwire.com --seeds gromwera.com
```

(minimist turns that into an array `seeds: [...]`
