### PR TITLE
gossip plugin now only tries to connect after existing connection closes

### DIFF
--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -67,7 +67,6 @@ module.exports = function (server) {
     server.closed = true
   })
   var scheduled = false
-  var nconns = 0
   function connect () {
     scheduled = false
     if(server.closed) return


### PR DESCRIPTION
@dominictarr It looks like `closed` is now fired if the connection fails or succeeds and is closed cleanly. This change reduces the noise in the log. I think the "one schedule at a time" protection was working (I didnt try to track how many connections got opened) but this reduces the noise in the log and makes it easier to tell what's happening.
