### PR TITLE
add trust and flag edges to friend graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "multiblob": "~1.2.0",
     "bash-color": "~0.0.3",
     "pull-inactivity": "~2.1.1",
-    "graphmitter": "~1.1.2",
+    "graphmitter": "~1.3.0",
     "non-private-ip": "~1.1.0",
     "ip": "~0.3.2"
   },

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -30,7 +30,12 @@ exports.init = function (sbot) {
       sbot.ssb.messagesByType({type: type, live: true}),
       pull.drain(function (msg) {
         var feed = msg.content.feed || msg.content.$feed
-        if(feed) graph.edge(msg.author, feed, true)
+        if(feed) {
+          if (msg.content.rel.slice(0, 2) == 'un')
+            graph.del(msg.author, feed)
+          else
+            graph.edge(msg.author, feed, true)
+        }
       })
     )
   }

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -20,39 +20,40 @@ exports.manifest = {
 
 exports.init = function (sbot) {
 
-  var graph = new Graphmitter()
+  var followGraph = new Graphmitter()
+  var trustGraph = new Graphmitter()
+  var flagGraph = new Graphmitter()
   var config = sbot.config
 
+  function index(graph, type) {
+    pull(
+      sbot.ssb.messagesByType({type: type, live: true}),
+      pull.drain(function (msg) {
+        var feed = msg.content.feed || msg.content.$feed
+        if(feed) graph.edge(msg.author, feed, true)
+      })
+    )
+  }
+
+  index(followGraph, 'follow')
+  index(trustGraph, 'trust')
+  index(flagGraph, 'flag')
+
   //handle the various legacy link types!
-  pull(
-    sbot.ssb.messagesByType({type: 'follow', live: true}),
-    pull.drain(function (msg) {
-      var feed = msg.content.feed || msg.content.$feed
-      if(feed) graph.edge(msg.author, feed, true)
-    })
-  )
-
-  pull(
-    sbot.ssb.messagesByType({type: 'follows', live: true}),
-    pull.drain(function (msg) {
-      var feed = msg.content.feed || msg.content.$feed
-      if(feed) graph.edge(msg.author, feed, true)
-    })
-  )
-
-  pull(
-    sbot.ssb.messagesByType({type: 'auto-follow', live: true}),
-    pull.drain(function (msg) {
-      var feed = msg.content.feed || msg.content.$feed
-      if(feed) graph.edge(msg.author, feed, true)
-    })
-  )
+  index(followGraph, 'follows')
+  index(followGraph, 'auto-follow')
 
   return {
-    all: function () {
-      return graph.toJSON()
+    all: function (graph) {
+      if (!graph || graph == 'follow' || graph == 'follows')
+        return followGraph.toJSON()
+      if (graph == 'trust' || graph == 'trusts')
+        return trustGraph.toJSON()
+      if (graph == 'flag' || graph == 'flags')
+        return flagGraph.toJSON()
+      return null
     },
-    hops: function (start) {
+    hops: function (start, graph) {
       var opts
       if(isString(start))
         opts = {start: start}
@@ -63,6 +64,15 @@ exports.init = function (sbot) {
       opts.start  = opts.start || sbot.feed.id
       opts.dunbar = conf.dunbar || 150
       opts.hops   = conf.hops   || 3
+
+      if (!graph || graph == 'follow' || graph == 'follows')
+        graph = followGraph
+      else if (graph == 'trust' || graph == 'trusts')
+        graph = trustGraph
+      else if (graph == 'flag' || graph == 'flags')
+        graph = flagGraph
+      else
+        throw new Error('Invalid graph type: '+graph)
 
       return graph.traverse(opts)
     }

--- a/test/friends.js
+++ b/test/friends.js
@@ -66,6 +66,68 @@ tape('construct and analyze graph', function (t) {
   })
 })
 
+tape('correctly delete edges', function (t) {
+
+  var u = require('./util')
+
+  var server = u.createDB('test-friends2', {
+      port: 45451, host: 'localhost', timeout: 1000,
+    }).use(require('../plugins/friends'))
+
+  var alice = server.feed
+  var bob = server.ssb.createFeed(ssbKeys.generate())
+  var carol = server.ssb.createFeed(ssbKeys.generate())
+
+  cont.para([
+    alice.add('follow', {feed: bob.id,   rel: 'follows'}),
+    alice.add('follow', {feed: carol.id, rel: 'follows'}),
+    alice.add('trust',  {feed: bob.id,   rel: 'trusts'}),
+
+    bob  .add('follow', {feed: alice.id, rel: 'follows'}),
+    bob  .add('trust',  {feed: alice.id, rel: 'trusts'}),
+    bob  .add('flag',   {feed: carol.id, rel: 'flags'}),
+
+    carol.add('follow', {feed: alice.id, rel: 'follows'}),
+
+    alice.add('follow', {feed: carol.id, rel: 'unfollows'}),
+    alice.add('trust',  {feed: bob.id,   rel: 'untrusts'}),
+    bob  .add('flag',   {feed: carol.id, rel: 'unflags'})
+  ]) (function () {
+
+    // kludge!
+    // have to wait a bit for the friends plugin to do its indexing (carol's follow is missed sometimes if we dont wait)
+    // feel free to improve
+    setTimeout(next, 500)
+
+    function next() {
+      var aliasMap = {}
+      aliasMap[alice.id] = 'alice'
+      aliasMap[bob.id]   = 'bob'
+      aliasMap[carol.id] = 'carol'
+      a = toAliases(aliasMap)
+
+      t.deepEqual(a(server.friends.all('follow')), { alice: { bob: true }, bob: { alice: true }, carol: { alice: true } })
+      t.deepEqual(a(server.friends.all('trust')),  { alice: {}, bob: { alice: true } })
+      t.deepEqual(a(server.friends.all('flag')),   { bob: {}, carol: {} })
+
+      t.deepEqual(a(server.friends.hops(alice.id, 'follow')), { alice: 0, bob: 1 })
+      t.deepEqual(a(server.friends.hops(alice.id, 'trust')), { alice: 0 })
+      t.deepEqual(a(server.friends.hops(alice.id, 'flag')), { alice: 0 })
+
+      t.deepEqual(a(server.friends.hops(bob.id, 'follow')), { bob: 0, alice: 1 })
+      t.deepEqual(a(server.friends.hops(bob.id, 'trust')), { bob: 0, alice: 1 })
+      t.deepEqual(a(server.friends.hops(bob.id, 'flag')), { bob: 0 })
+
+      t.deepEqual(a(server.friends.hops(carol.id, 'follow')), { carol: 0, alice: 1, bob: 2 })
+      t.deepEqual(a(server.friends.hops(carol.id, 'trust')), { carol: 0 })
+      t.deepEqual(a(server.friends.hops(carol.id, 'flag')), { carol: 0 })
+
+      t.end()
+      server.close()
+    }
+  })
+})
+
 function toAliases(aliasMap) {
   return function (g) {
     var g_ = {}

--- a/test/friends.js
+++ b/test/friends.js
@@ -1,0 +1,86 @@
+var ssbKeys = require('ssb-keys')
+var cont    = require('cont')
+var tape    = require('tape')
+
+// create 3 feeds
+// add some of friend edges (follow, trust, flag)
+// make sure the friends plugin analyzes correctly
+
+tape('construct and analyze graph', function (t) {
+
+  var u = require('./util')
+
+  var server = u.createDB('test-friends1', {
+      port: 45451, host: 'localhost', timeout: 1000,
+    }).use(require('../plugins/friends'))
+
+  var alice = server.feed
+  var bob = server.ssb.createFeed(ssbKeys.generate())
+  var carol = server.ssb.createFeed(ssbKeys.generate())
+
+  cont.para([
+    alice.add('follow', {feed: bob.id,   rel: 'follows'}),
+    alice.add('follow', {feed: carol.id, rel: 'follows'}),
+    alice.add('trust',  {feed: bob.id,   rel: 'trusts'}),
+
+    bob  .add('follow', {feed: alice.id, rel: 'follows'}),
+    bob  .add('trust',  {feed: alice.id, rel: 'trusts'}),
+    bob  .add('flag',   {feed: carol.id, rel: 'flags'}),
+
+    carol.add('follow', {feed: alice.id, rel: 'follows'})
+  ]) (function () {
+
+    // kludge!
+    // have to wait a bit for the friends plugin to do its indexing (carol's follow is missed sometimes if we dont wait)
+    // feel free to improve
+    setTimeout(next, 500)
+
+    function next() {
+      var aliasMap = {}
+      aliasMap[alice.id] = 'alice'
+      aliasMap[bob.id]   = 'bob'
+      aliasMap[carol.id] = 'carol'
+      a = toAliases(aliasMap)
+
+      t.deepEqual(a(server.friends.all()),         { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
+      t.deepEqual(a(server.friends.all('follow')), { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
+      t.deepEqual(a(server.friends.all('trust')),  { alice: { bob: true }, bob: { alice: true } })
+      t.deepEqual(a(server.friends.all('flag')),   { bob: { carol: true }, carol: {} })
+
+      t.deepEqual(a(server.friends.hops(alice.id)), { alice: 0, bob: 1, carol: 1 })
+      t.deepEqual(a(server.friends.hops(alice.id, 'follow')), { alice: 0, bob: 1, carol: 1 })
+      t.deepEqual(a(server.friends.hops(alice.id, 'trust')), { alice: 0, bob: 1 })
+      t.deepEqual(a(server.friends.hops(alice.id, 'flag')), { alice: 0 })
+
+      t.deepEqual(a(server.friends.hops(bob.id, 'follow')), { bob: 0, alice: 1, carol: 2 })
+      t.deepEqual(a(server.friends.hops(bob.id, 'trust')), { bob: 0, alice: 1 })
+      t.deepEqual(a(server.friends.hops(bob.id, 'flag')), { bob: 0, carol: 1 })
+
+      t.deepEqual(a(server.friends.hops(carol.id, 'follow')), { carol: 0, alice: 1, bob: 2 })
+      t.deepEqual(a(server.friends.hops(carol.id, 'trust')), { carol: 0 })
+      t.deepEqual(a(server.friends.hops(carol.id, 'flag')), { carol: 0 })
+
+      t.end()
+      server.close()
+    }
+  })
+})
+
+function toAliases(aliasMap) {
+  return function (g) {
+    var g_ = {}
+    for (var k in g) {
+      var k_ = aliasMap[k]
+      if (typeof g[k] == 'object') {
+        g_[k_] = {}
+        for (var l in g[k]) {
+          var l_ = aliasMap[l]
+          g_[k_][l_] = g[k][l]
+        }
+      } else {
+        g_[k_] = g[k]
+      }
+    }
+    return g_
+  }
+}


### PR DESCRIPTION
modifies the friend plugin functions to optionally take the desired graph

```js
server.friends.all('follow')
server.friends.all() // same as ^
server.friends.all('trust')
server.friends.all('flag')

server.friends.hops(alice, 'follow')
server.friends.hops(alice, 'trust')
server.friends.hops(alice, 'flag')
```

also adds edge-deletion to the graph construction