### PR TITLE
update sbot to use new ssb object formats {key:, value:}

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pull-stringify": "~1.2.2",
     "pull-ws-server": "~1.1.1",
     "rc": "~0.5.4",
-    "secure-scuttlebutt": "~7.0.4",
+    "secure-scuttlebutt": "~8.0.0",
     "ssb-keys": "~0.4.1",
     "stream-to-pull-stream": "~1.6.0",
     "explain-error": "~1.0.1",

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -27,7 +27,7 @@ exports.init = function (sbot) {
 
   function index(graph, type) {
     pull(
-      sbot.ssb.messagesByType({type: type, live: true}),
+      sbot.ssb.messagesByType({type: type, keys: false, live: true}),
       pull.drain(function (msg) {
         var feed = msg.content.feed || msg.content.$feed
         if(feed) {

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -97,7 +97,7 @@ module.exports = {
     var port = config.port
 
     pull(
-      server.ssb.messagesByType({type: 'pub', live: true}),
+      server.ssb.messagesByType({type: 'pub', live: true, keys: false}),
       pull.map(function (e) {
         var o = toAddress(e.content.address)
         return o

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -38,7 +38,7 @@ function replicate(server, rpc, cb) {
     pull(
       latest(),
       pull.drain(function (upto) {
-        sources.add(rpc.createHistoryStream({id: upto.id, seq: upto.sequence + 1, live: live}))
+        sources.add(rpc.createHistoryStream({id: upto.id, seq: upto.sequence + 1, live: live, keys: false}))
       }, function (err) {
         if(err)
           server.emit('log:error', ['replication', rep._sessid, 'error', err])

--- a/test/client-auth.js
+++ b/test/client-auth.js
@@ -30,7 +30,7 @@ tape('test api', function (t) {
     t.ok(authed.granted)
     client.add({type: 'msg', value: 'hello'}, function (err, data) {
       if(err) throw err
-      t.equal(data.content.value, 'hello')
+      t.equal(data.value.content.value, 'hello')
       client.close(function() {
         server.close()
         t.end()

--- a/test/realtime.js
+++ b/test/realtime.js
@@ -39,7 +39,7 @@ tape('replicate between 3 peers', function (t) {
 
     var ary = []
     pull(
-      bobDb.ssb.createHistoryStream({id: alice.id, seq: 0, live: true}),
+      bobDb.ssb.createHistoryStream({id: alice.id, seq: 0, keys: false, live: true}),
       pull.through(function (data) {
         console.log(data)
         ary.push(data);
@@ -52,7 +52,7 @@ tape('replicate between 3 peers', function (t) {
         clearInterval(int)
         var _ary = []
           pull(
-            bobDb.ssb.createHistoryStream({id: alice.id, sequence: 0, live: true}),
+            bobDb.ssb.createHistoryStream({id: alice.id, sequence: 0, keys: false, live: true}),
             pull.through(function (msg) {
               _ary.push(msg)
               if(_ary.length < 12) return
@@ -69,8 +69,8 @@ tape('replicate between 3 peers', function (t) {
       }
       else
         alice.add({type: 'test', value: new Date()},
-          function (err, msg, hash){
-            console.log('added', hash, msg.sequence)
+          function (err, msg){
+            console.log('added', msg.key, msg.value.sequence)
           })
     }, 200)
 


### PR DESCRIPTION
keeps in sync with ssb after https://github.com/ssbc/secure-scuttlebutt/pull/77 change