### PR TITLE
standardized cfg host/hostname to host

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ var path = require('path')
 var nonPrivate = require('non-private-ip')
 
 module.exports = require('rc')('ssb', {
-  hostname: nonPrivate() || '',
+  host: nonPrivate() || '',
   port: 2000,
   timeout: 30000,
   pub: true,

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ exports = module.exports = function (config, ssb, feed) {
   }
 
   server.getAddress = function() {
-    var address = server.config.hostname || server.config.host || nonPrivate.private() || 'localhost'
+    var address = server.config.host || nonPrivate.private() || 'localhost'
     if (server.config.port != DEFAULT_PORT)
       address += ':' + server.config.port
     return address


### PR DESCRIPTION
this was the cause of #83, i was using hostname and the gossip plugin was using host. this PR standardizes the config so this confusion wont occur again