### PR TITLE
fix: blobs now consistently download when discovered on a peer

### DIFF
--- a/plugins/blobs.js
+++ b/plugins/blobs.js
@@ -210,8 +210,8 @@ module.exports = {
     var download = oneTrack(function (done) {
       var wantList = getWantList('ready')
         .filter(function (e) {
-          return first(e.has, function (_, k) {
-            return remotes[k]
+          return first(e.has, function (has, k) {
+            return has && remotes[k]
           })
         })
 


### PR DESCRIPTION
there was an error condition where blobs were transferred sometimes but not always. a blob would be "found" on a peer, but then not fetch

turns out the download function had a logical error that would crop up in certain arrangements of data. if the ready `want` list looked like...

```js
[ { id: 'dgkRMPt9u0a9v3I9mrYZkbKbX97LIuSgTLXxa5qsfX8=.blake2s',
    waiting: [ [Function] ],
    state: 'ready',
    has: 
     { 'TNn7v0MsAs8OpQnyRwtsMeROVWGlKnS/ItX966PAWjI=.blake2s': false,
       'kIetR4xx26Q2M62vG0tNrptJDFnxP0SexLHaOIkyy08=.blake2s': true } } ]
```

the download wouldnt happen. the `TNn7v0M...` peer was getting selected to download from because it was the first active peer, even though it was marked as not having the file. the download function would select `TNn7v0M`, see the file wasnt there, then abort