### PR TITLE
added gossip.connect rpc method

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ssb-keys": "~0.4.1",
     "ssb-msgs": "~2.0.0",
     "ssb-msg-schemas": "~1.0.0",
-    "ssbplug-phoenix": "~2.2.6",
+    "ssbplug-phoenix": "~2.2.10",
     "stream-to-pull-stream": "~1.6.0",
     "explain-error": "~1.0.1",
     "map-merge": "~1.1.0",


### PR DESCRIPTION
new rpc function in the gossip plugin lets us trigger syncs manually, eg from phoenix's address page

decided to implement it, for now, such that it only connects to known peers. however, we could improve it to allow previously-unknown peers if we feel that's useful