### PR TITLE
manage plugin http use with connect.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var mkdirp     = require('mkdirp')
 var crypto     = require('crypto')
 var ssbKeys    = require('ssb-keys')
 var multicb    = require('multicb')
+var connect    = require('connect')
 var inactive   = require('pull-inactivity')
 var nonPrivate = require('non-private-ip')
 
@@ -189,6 +190,26 @@ exports = module.exports = function (config, ssb, feed) {
   // ======================
   var sessions = {}
 
+
+  // http interface (via connect)
+  // ============================
+  //
+  // http should be considered a legacy interface,
+  // but we need it to work around various legacy
+  // browser things. You should build most of your
+  // app with the rpc api and not the http api.
+
+  server.http = connect()
+  server.on('request', server.http)
+
+  //default handlers
+
+  server.http.use(function (req, res, next) {
+    if(req.url = '/manifest.json')
+      res.end(JSON.stringify(server.getManifest(), null, 2) + '\n')
+    else
+      next()
+  })
 
   // plugin management
   // =================

--- a/index.js
+++ b/index.js
@@ -204,9 +204,17 @@ exports = module.exports = function (config, ssb, feed) {
 
   //default handlers
 
+  function stringManifest () {
+    return JSON.stringify(server.getManifest(), null, 2) + '\n'
+  }
+
   server.http.use(function (req, res, next) {
-    if(req.url = '/manifest.json')
-      res.end(JSON.stringify(server.getManifest(), null, 2) + '\n')
+    if(req.url == '/manifest.json')
+      res.end(stringManifest())
+    //return manifest as JS GLOBAL,
+    //so that it can be easily loaded into plugins, without hardcoding.
+    else if(req.url == '/manifest.js')
+      res.end(';SSB_MANIFEST = ' + stringManifest())
     else
       next()
   })

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "graphmitter": "~1.3.0",
     "non-private-ip": "~1.1.0",
     "ip": "~0.3.2",
-    "ssb-config": "~1.0.0"
+    "ssb-config": "~1.0.0",
+    "connect": "~3.3.4"
   },
   "devDependencies": {
     "rimraf": "~2.2.8",


### PR DESCRIPTION
This change was necessary to make my dynamic-manifest pull request to phoenix.

The main upside of this change is it enables more than one plugin to add http handlers,
Also, it serves the manifest (as either json or js) and the blobs plugin hosts hosts blobs.

Ultimately, this means that the manifest only needs to be maintained in one place.