### PR TITLE
package.json fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "tape": "~3.0.0",
     "level-test": "~1.6.6",
     "deep-equal": "~0.2.1",
-    "level-sublevel": "~6.3.15",
-    "osenv": "~0.1.0"
+    "level-sublevel": "~6.3.15"
   },
   "bin": {
     "sbot": "./bin.js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "pull-stream-to-stream": "~1.3.0",
     "pull-stringify": "~1.2.2",
     "pull-ws-server": "~1.1.1",
-    "rc": "~0.5.4",
     "secure-scuttlebutt": "~8.1.3",
     "ssb-keys": "~0.4.1",
     "ssb-msgs": "~2.0.0",


### PR DESCRIPTION
Gets rid of this warning

```
$ npm i
npm WARN package.json Dependency 'osenv' exists in both dependencies and devDependencies, using 'osenv@~0.1.0' from dependencies
```

Also `rc` is no longer used