### PR TITLE
when ssb-client connects, do not treat it as authed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ exports = module.exports = function (config, ssb, feed) {
       ts: Date.now(),
     }), function (err, res) {
 
-      if(err) {
+      if(err || !res) {
         server.emit('rpc:unauthorized', err)
         rpc._emit('rpc:unauthorized', err)
         server.emit('log:warning', ['sbot', rpc._sessid, 'unauthed', err])


### PR DESCRIPTION
this emits an "unauthorized" event, but, since ssb-client now cb() silently, it does not dump a confusing error either. Without this, since some plugins expect auth's cb to have arguments, scuttlebot was crashing. This fixes that, and makes ssb-client work.