### PR TITLE
more convienient queries with mynosql-query

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -10,6 +10,7 @@ var explain    = require('explain-error')
 var ssbKeys    = require('ssb-keys')
 var stringify  = require('pull-stringify')
 var createHash = require('multiblob/util').createHash
+var parse      = require('mynosql-query')
 
 var config  = require('ssb-config')
 
@@ -60,7 +61,10 @@ function usage () {
 var opts = require('minimist')(process.argv.slice(2))
 var cmd = opts._[0]
 var arg = opts._[1]
+
 delete opts._
+
+console.error(parse(arg))
 
 var manifestFile = path.join(config.path, 'manifest.json')
 
@@ -157,6 +161,14 @@ function next (data) {
         throw explain(err, 'auth failed')
     }
 
+    console.log(cmd, arg, data)
+
+    if(cmd.toString() === 'query' && arg) {
+      data = !isObject(data) ? {} : data
+      data.query = parse(arg)
+      console.error(data)
+    }
+
     // handle add specially, so that external links (ext)
     // can be detected, and files uploaded first.
     // then the message is created and everything is in a valid state.
@@ -203,6 +215,7 @@ function next (data) {
       }
 
     }
+
     else if('async' === type || type === 'sync') {
       get(rpc, cmd)(data, function (err, ret) {
         if(err) throw err

--- a/bin.js
+++ b/bin.js
@@ -64,8 +64,6 @@ var arg = opts._[1]
 
 delete opts._
 
-console.error(parse(arg))
-
 var manifestFile = path.join(config.path, 'manifest.json')
 
 cmd = aliases[cmd] || cmd
@@ -160,8 +158,6 @@ function next (data) {
       else
         throw explain(err, 'auth failed')
     }
-
-    console.log(cmd, arg, data)
 
     if(cmd.toString() === 'query' && arg) {
       data = !isObject(data) ? {} : data

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "non-private-ip": "~1.1.0",
     "ip": "~0.3.2",
     "ssb-config": "~1.0.0",
-    "connect": "~3.3.4"
+    "connect": "~3.3.4",
+    "mynosql-query": "~1.0.0"
   },
   "devDependencies": {
     "rimraf": "~2.2.8",


### PR DESCRIPTION
this adds a special case to the cli tool to use mynqsql-query to parse queries.
it makes it easy to query the data base with a one liner.

for example, get all messages where the first message (after init) is a post

``` bash
sbot query 'sequence=1, content.type=post'
```
will produce a lot of JSON output.
