### PR TITLE
Init empty feed when starting server

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -72,6 +72,12 @@ if(cmd === 'server') {
   require('./').init(config, function (err, server) {
     if(err) throw err
 
+    // Ensure the feed is init'd
+    server.ssb.getLatest(keys.id, function (err, msg) {
+      if(err) throw err
+      if(!msg) server.feed.init()
+    });
+
     fs.writeFileSync(
       manifestFile,
       JSON.stringify(server.getManifest(), null, 2)

--- a/bin.js
+++ b/bin.js
@@ -74,7 +74,6 @@ if(cmd === 'server') {
 
     // Ensure the feed is init'd
     server.ssb.getLatest(keys.id, function (err, msg) {
-      if(err) throw err
       if(!msg) server.feed.init()
     });
 


### PR DESCRIPTION
This should cause a server with an empty feed (e.g. newly created keypair) to publish an init message when it starts serving. This would address ssbc/phoenix#367 by ensuring that pub servers have profiles, and that their createdAt timestamp will be the time at which the server first started serving.