### PR TITLE
Fixes for local feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pull-stream": "~2.24.1",
     "pull-stream-to-stream": "~1.3.0",
     "pull-stringify": "~1.2.2",
-    "pull-ws-server": "~1.1.1",
+    "pull-ws-server": "~1.3.1",
     "secure-scuttlebutt": "~10.1.0",
     "ssb-keys": "~0.6.1",
     "ssb-msgs": "~3.0.0",

--- a/plugins/invite.js
+++ b/plugins/invite.js
@@ -26,6 +26,7 @@ module.exports = {
     addMe: 'async'
   },
   permissions: {
+    local: {allow: ['use']},
     anonymous: {allow: ['use']}
   },
   init: function (server) {


### PR DESCRIPTION
Outdated pull-ws-server dep was keeping the auth code from correctly detecting local auth.

Fixing that caused the invites tests to fail, as the test user was correctly authing locally, which didnt have the `invite.use` perms. Fixed that by giving `invite.use` access to the local role.