### PR TITLE
add perms to blobs.has and blobs.get to local role

### DIFF
--- a/plugins/blobs.js
+++ b/plugins/blobs.js
@@ -90,6 +90,7 @@ module.exports = {
   },
   permissions: {
     anonymous: {allow: ['has', 'get']},
+    local: {allow: ['has', 'get']}
   },
   init: function (sbot) {
 


### PR DESCRIPTION
fixes a bug in the blobs plugin (shown by the blobs tests) that was introduced when the local role began correctly being recognized