### PR TITLE
Tracking PR for replication performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ exports = module.exports = function (config, ssb, feed) {
   function attachSession (stream, incoming, cb) {
     var rpc = peerApi(server.manifest, api)
                 .permissions({allow: ['auth']})
+    var timeout = server.config.timeout || 30e3
     var rpcStream = rpc.createStream()
-    rpcStream = inactive(rpcStream, server.config.timeout)
+    rpcStream = inactive(rpcStream, timeout)
     pull(stream, rpcStream, stream)
 
     rpc.incoming = incoming

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "minimist": "~1.1.0",
     "mkdirp": "~0.5.0",
     "multicb": "^1.0.0",
-    "muxrpc": "~3.3.5",
+    "muxrpc": "~4.0.1",
     "nomnom": "1.8.0",
     "osenv": "~0.1.0",
     "pull-cat": "~1.1.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "multiblob": "~1.4.1",
     "bash-color": "~0.0.3",
     "pull-inactivity": "~2.1.1",
-    "graphmitter": "~1.3.0",
+    "graphmitter": "~1.4.0",
     "non-private-ip": "~1.1.0",
     "ip": "~0.3.2",
     "ssb-config": "~1.0.0",
@@ -49,7 +49,10 @@
     "level-test": "~1.6.6",
     "deep-equal": "~0.2.1",
     "level-sublevel": "~6.3.15",
-    "ssb-msg-schemas": "~3.1.0"
+    "ssb-msg-schemas": "~3.1.0",
+    "cat-names": "~1.0.2",
+    "dog-names": "~1.0.2",
+    "pull-paramap": "~1.1.1"
   },
   "bin": {
     "sbot": "./bin.js"

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -2,6 +2,7 @@ var Graphmitter = require('graphmitter')
 var pull        = require('pull-stream')
 var mlib        = require('ssb-msgs')
 var memview     = require('level-memview')
+var pushable    = require('pull-pushable')
 
 function isFunction (f) {
   return 'function' === typeof f
@@ -15,7 +16,8 @@ exports.name = 'friends'
 exports.version = '1.0.0'
 exports.manifest = {
   all  : 'async',
-  hops : 'async'
+  hops : 'async',
+  createFriendStream: 'source',
 }
 
 exports.init = function (sbot) {
@@ -36,6 +38,7 @@ exports.init = function (sbot) {
             graphs.follow.edge(msg.value.author, link.feed, true)
           else
             graphs.follow.del(msg.value.author, link.feed)
+
         }
         if ('trust' in c) {
           var trust = c.trust|0
@@ -60,6 +63,28 @@ exports.init = function (sbot) {
         cb(null, graphs[graph] ? graphs[graph].toJSON() : null)
       })
     },
+
+    createFriendStream: function (opts) {
+      opts = opts || {}
+      var start = opts.start || sbot.feed.id
+      var graph = graphs[opts.graph || 'follow']
+      if(!graph)
+        return pull.error(new Error('unknown graph:' + opts.graph))
+      var cancel, ps = pushable(function () {
+        cancel && cancel()
+      })
+      var conf = config.friends || {}
+      cancel = graph.traverse({
+        start: start || sbot.feed.id,
+        hops: opts.hops || conf.hops || 3,
+        max: opts.dunbar || conf.dunbar || 150,
+        each: function (_, to) {
+          ps.push(to)
+        }
+      })
+      return ps
+    },
+
     hops: function (start, graph, opts, cb) {
       if (typeof opts == 'function') { // (start|opts, graph, cb)
         cb = opts

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -234,7 +234,7 @@ module.exports = {
         p.time.connect = 0
       p.time.attempt = Date.now()
       p.connected = true
-      
+
       var rpc = server.connect(p)
       rpc._peer = p
       rpc.on('remote:authorized', function () {

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -10,8 +10,6 @@ function replicate(server, rpc, cb) {
 
     var live = !!config.timeout
 
-    var progress = function () {}
-
     var sources = many()
     var sent = 0
 
@@ -19,7 +17,6 @@ function replicate(server, rpc, cb) {
       server.friends.createFriendStream(),
       ssb.createLatestLookupStream(),
       pull.drain(function (upto) {
-        console.log('get', upto)
         sources.add(rpc.createHistoryStream({
           id: upto.id, seq: upto.sequence + 1,
           live: live, keys: false

--- a/test/random.js
+++ b/test/random.js
@@ -1,0 +1,166 @@
+var pull      = require('pull-stream')
+
+var paramap   = require('pull-paramap')
+
+var tape      = require('tape')
+
+var u    = require('./util')
+var cats = require('cat-names')
+var dogs = require('dog-names')
+
+//build a random network, with n members.
+
+function generateAnimals (sbot, n, cb) {
+  var ssb = sbot.ssb
+  var a = [sbot.feed]
+  while(n --> 0) {
+    a.push(ssb.createFeed())
+  }
+
+  console.log('generate NAMES')
+
+  pull(
+    pull.values(a),
+    paramap(function (feed, cb) {
+      var animal = Math.random() > 0.5 ? 'cat' : 'dog'
+      var name   = animal == 'cat' ? cats.random() : dogs.allRandom()
+      feed.name = name
+      MSGS ++
+      feed.add({
+        type: 'contact',
+        contact: {feed: feed.id},
+        name: name, animal: animal
+      }, cb)
+    }, 10),
+    pull.drain(null, function (err) {
+      if(err) return cb(err)
+
+      console.log('generate FRIENDS')
+
+      pull(
+        pull.values(a),
+        paramap(function (me, cb) {
+          var friends = []
+          var n = 3
+          while(n --> 0 || Math.random() > 0.2)
+            friends.push(a[~~(Math.random()*a.length)])
+
+          pull(
+            pull.values(friends),
+            paramap(function (f, cb) {
+              me.add({
+                type: 'contact',
+                contact: { feed: f.id },
+                following: true,
+                name: f.name
+              }, cb)
+            }, 10),
+            pull.drain(null, cb)
+          )
+        }, 10),
+        pull.drain(null, cb)
+      )
+
+    })
+  )
+
+}
+
+var friends = require('../plugins/friends')
+var gossip = require('../plugins/gossip')
+var replicate = require('../plugins/replicate')
+
+
+function latest (sbot, cb) {
+
+  sbot.friends.hops({hops: 2}, function (err, keys) {
+    if(err) return cb(err)
+
+    var get = 
+        sbot.ssb.sublevel('lst').get
+    var n = 0, map = {}
+    for(var k in keys) (function (key) {
+      n++
+      get(key, function (err, value) {
+        map[key] = value
+        if(--n) return
+        cb(null, map)
+      })
+    })(k)
+
+  })
+
+}
+
+tape('replicate social network for animals', function (t) {
+
+  var animalNetwork = u.createDB('test-random-animals', {
+    port: 45451, host: 'localhost', //timeout: 2001
+  }).use(friends).use(replicate)
+
+    if(!animalNetwork.friends)
+      throw new Error('missing frineds plugin')
+
+  generateAnimals(animalNetwork, 100, function (err) {
+    if(err) throw err
+    console.log('replicate GRAPH')
+    var c = 0
+    latest(animalNetwork, function (err, latest) {
+
+      var seen = {}
+      var start = Date.now()
+      var animalFriends = u.createDB('test-random-animals2', {
+        port: 45452, host: 'localhost', //timeout: 2001,
+        seeds: [{port: 45451, host: 'localhost'}]
+      }).use(friends).use(replicate).use(gossip)
+
+      animalFriends.on('rpc:connect', function () {
+        console.log('CONNECTION', Date.now(), c++)
+      })
+
+      if(!animalFriends.friends)
+        throw new Error('missing friends plugin')
+
+      animalFriends.feed.add({
+        type: 'contact',
+        contact: {feed: animalNetwork.feed.id},
+        following: true
+      }, function (err) {
+        if(err) throw err
+        console.log("friended")
+      })
+
+
+      console.log('LIVE stream...')
+      pull(
+        animalFriends.ssb.createLogStream({live: true}),
+        pull.drain(function (data) {
+          if(data.sync) return
+          seen[data.value.author] = data.value.sequence
+          var total = 0, prog = 0
+          for(var k in latest) {
+            total += latest[k]
+            prog += (seen[k] || 0)
+          }
+          console.log("REPLICATED", prog, total, Math.round(100*(prog/total)))
+          if(total === prog) {
+            var seconds = (Date.now() - start)/1000
+            t.equal(c, 1)
+            t.equal(prog, total)
+
+            console.log("DONE", seconds, c, total/seconds)
+            animalFriends.close()
+            animalNetwork.close()
+            t.end()
+
+            //UGLY! TODO: make test close down properly.
+            //******************************************
+            process.exit(0)
+            //******************************************
+          }
+
+        })
+      )
+    })
+  })
+})

--- a/test/random.js
+++ b/test/random.js
@@ -25,7 +25,6 @@ function generateAnimals (sbot, n, cb) {
       var animal = Math.random() > 0.5 ? 'cat' : 'dog'
       var name   = animal == 'cat' ? cats.random() : dogs.allRandom()
       feed.name = name
-      MSGS ++
       feed.add({
         type: 'contact',
         contact: {feed: feed.id},


### PR DESCRIPTION
Adds a crude benchmark and some fixes to make replication faster.

benchmarks of a fullish network (100 users, ~ 1000 messages) to a new user. It's currently taking 1 minute, and about 17 seconds to replicate 1000 messages. including generate 1k messages.
To replicate the receiving client verifies about 400 signatures (if it queues a few messages it just verifies the last one in the current queue).

I also benchmarked some signing libraries (not in this PR though) - eccjs (which we use) can verify 100 signatures in 4 seconds. Slow. To verify 400 signatures would take 14 seconds, which accounts for most of the time to replicate.

I also looked at some other libraries - ecma-nacl is twice as fast (in browser or server). elliptic is way faster on node but slower on the browser (? not sure why ?)

But, I think we should go with nacl. This is already a port of a specific C implementation, which will be really fast (although the node bindings are currently not working... https://www.npmjs.com/package/nacl)

NOTE: this pr breaks the test/server.js because that test doesn't detect the successful replication correctly anymore. Implementing a progress bar would solve this.