### PR TITLE
blob RPC usage limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,13 @@ exports = module.exports = function (config, ssb, feed) {
 
     rpc.incoming = incoming
     rpc.outgoing = !incoming
+    rpc.usage = {
+      blobs: {
+        queries: 0,
+        transfers: 0,
+        bytes: 0
+      }
+    }
 
     rpc._sessid = ++sessCounter
     rpc._remoteAddress = stream.remoteAddress


### PR DESCRIPTION
This PR adds resource-usage tracking to connections, and removes permissions to the RPC API when configured thresholds are exceeded. Connections authorized as 'master' won't be subject to limiting.

This will track only resource usage in a single connection's life time. It will not handle multiple connections by a given user, or the server's overall resource availability.

This PR will track and limit the usage of:

 - blobs: # of files queried for
 - blobs: # of files transferred

In the future, we may also want to track and limit:

 - blobs: # of bytes transferred
 - # of RPC calls in the connection
 - # of RPC calls within a window (no flooding)
 - # of feeds replicated
 - connection lifespan (eg cant hold open connection > 5 mins)

Tracking will be handled by attaching a `usage` object to the `rpc` object. RPC methods will increment relevant metrics and check against configured limits before running their behaviors. In the future, we may want to bake the tracking and limiting into muxrpc, but I decided to have functions do it "manually" while we learn the problem space.

Config for limiting is under the `limits` object. The `ssb-config` repo will need updating. The additional config is:

```js
{
//...
  limits: {
    blob: {
      queries: 5, // I have this low because it's usually done in bulk
      transfers: 50
    }
  }
//...
}