### PR TITLE
Replication Progress

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -25,6 +25,7 @@ function api (server) {
     if(ssb[name])
       api[name] = function () {
         var args = [].slice.call(arguments)
+        this._emit('call:'+name, args[0])
         return ssb[name].apply(ssb, args)
       }
   })

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pull-stream-to-stream": "~1.3.0",
     "pull-stringify": "~1.2.2",
     "secret-handshake": "0.1.1",
-    "secure-scuttlebutt": "^11.0.0",
+    "secure-scuttlebutt": "^11.1.0",
     "ssb-config": "~1.0.0",
     "ssb-feed": "~0.1.2",
     "ssb-keys": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mynosql-query": "~1.0.0",
     "nomnom": "1.8.0",
     "non-private-ip": "~1.1.0",
+    "observ-debounce": "^1.0.0",
     "packet-stream-codec": "~1.1.0",
     "pull-abortable": "~4.0.0",
     "pull-cat": "~1.1.5",
@@ -42,7 +43,8 @@
     "ssb-msg-schemas": "~3.2.1",
     "ssb-msgs": "~3.1.2",
     "ssb-ref": "0.0.0",
-    "stream-to-pull-stream": "~1.6.0"
+    "stream-to-pull-stream": "~1.6.0",
+    "observ": "~0.2.0"
   },
   "devDependencies": {
     "cat-names": "~1.0.2",

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -44,7 +44,7 @@ function replicate(server, rpc, cb) {
       ssb.createLatestLookupStream(),
       pull.drain(function (upto) {
         to_recv[upto.id] = upto.sequence
-        //replicated[upto.id] = upto.sequence
+        replicated[upto.id] = upto.sequence
         sources.add(rpc.createHistoryStream({
           id: upto.id, seq: upto.sequence + 1,
           live: live, keys: false

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -3,6 +3,8 @@ var pushable = require('pull-pushable')
 var many = require('pull-many')
 var cat = require('pull-cat')
 var Abort = require('pull-abortable')
+var Debounce = require('observ-debounce')
+var Observ = require('observ')
 
 function replicate(server, rpc, cb) {
     var ssb = server.ssb
@@ -14,12 +16,35 @@ function replicate(server, rpc, cb) {
     var sources = many()
     var sent = 0
 
+    var to_send = {}, to_recv = {}
+
+    rpc.on('call:createHistoryStream', function (opts) {
+      to_send[opts.id] = (opts.sequence || opts.seq) - 1
+    })
+
+    rpc.progress = Observ()
+
+    var set_progress = rpc.progress.set
+    delete rpc.progress.set
+
+    rpc._emit('replicate:progress', rpc.progress)
+
+    //these defaults are for replication
+    //so they belong in the replication config
+    var opts = config.replication || {}
+    opts.hops = opts.hops || 3
+    opts.dunbar = opts.dunbar || 150
+
     pull(
-      server.friends.createFriendStream(),
+      server.friends.createFriendStream(opts),
       aborter,
+      pull.through(function (s) {
+        to_recv[s] = 0
+      }),
       ssb.createLatestLookupStream(),
       pull.drain(function (upto) {
-        replicated[upto.id] = upto.sequence
+        to_recv[upto.id] = upto.sequence
+        //replicated[upto.id] = upto.sequence
         sources.add(rpc.createHistoryStream({
           id: upto.id, seq: upto.sequence + 1,
           live: live, keys: false
@@ -31,6 +56,20 @@ function replicate(server, rpc, cb) {
       })
     )
 
+    var debounce = Debounce(100)
+    debounce(function () {
+      var d = 0, r = 0
+      for(var id in to_recv) {
+        var S = to_send[id] || 0, R = to_recv[id] || 0
+        var D = replicated[id] || 0
+        if(to_send[id] != null && to_recv[id] != null && S > R) {
+          d += (S - R); r += (D - R)
+        }
+      }
+      set_progress({total: d, progress: r})
+    })
+    var progress = debounce.set
+
     var replicated = {}
 
     pull(
@@ -40,9 +79,11 @@ function replicate(server, rpc, cb) {
           replicated[msg.author]||0,
           msg.sequence
         )
+        progress()
       }),
       ssb.createWriteStream(function (err) {
         aborter.abort()
+        progress ()
         cb(err, replicated)
       })
     )


### PR DESCRIPTION
This allows you to track real time replication progress.
when you run `test/random.js` you'll see a simple ascii progress bar, too.

The replication plugin adds a progress observ(able) to the rpc object,
and if you pass it a listener it'll be updated with the current progress.
It is only updated every 100 ms, max.