### PR TITLE
use key instead of hash(key) as rpc.id

### DIFF
--- a/client.js
+++ b/client.js
@@ -51,7 +51,7 @@ module.exports = function (keys, manf) {
 
         var rpc = peerApi.clientApi(manf, {}, {})
         .permissions({allow: ['emit'], deny: null})
-        rpc.id = hash(address.key)
+        rpc.id = address.key
         rpc.address = address
 
         rpc.client = true

--- a/test/random.js
+++ b/test/random.js
@@ -176,7 +176,7 @@ tape('replicate social network for animals', function (t) {
             prog += (seen[k] || 0)
           }
 //          console.log("REPLICATED", prog, total, Math.round(100*(prog/total)))
-          if(total === prog) {
+          if(total === prog && total !== 0) {
             var seconds = (Date.now() - start)/1000
             t.equal(c, 1)
             t.equal(prog, total)


### PR DESCRIPTION
Using `hash(address.key)` was causing a bug in `invite.accept()`, as it was following the `rpc.id` and therefore not following the feed id