### PR TITLE
Readd index rebuilding

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -79,7 +79,19 @@ cmd = aliases[cmd] || cmd
 
 if(cmd === 'server') {
   config.keys = keys
-  createSbot(config)
+  var sbot = createSbot(config)
+  sbot.getSSB().needsRebuild(function (err, b) {
+    if (b) {
+      console.log('Rebuilding indexes to ensure consistency. Please wait...')
+      sbot.getSSB().rebuildIndex(function (err) {
+        if (err)
+          console.log(explain(err, 'error while rebuilding index'))
+        else
+          console.log('Indexes rebuilt.')
+      })
+    }
+  })
+
 //  require('./').init(config, function (err, server) {
 //    if(err) throw err
 //

--- a/index.js
+++ b/index.js
@@ -73,6 +73,8 @@ var SSB = {
     var ssb = create(opts.path, null, opts.keys)
     var feed = ssb.createFeed(opts.keys)
     return {
+      ssb                      : ssb,
+      
       id                       : feed.id,
       publish                  : feed.add,
       add                      : ssb.add,

--- a/index.js
+++ b/index.js
@@ -73,8 +73,8 @@ var SSB = {
     var ssb = create(opts.path, null, opts.keys)
     var feed = ssb.createFeed(opts.keys)
     return {
-      ssb                      : ssb,
-      
+      getSSB                   : function () { return ssb },
+
       id                       : feed.id,
       publish                  : feed.add,
       add                      : ssb.add,


### PR DESCRIPTION
Conditional index-rebuilding got lost in the refactor

This is where, on load, SSB compares a vmajor stored in level against the vmajor of the SSB package.json. If they aren't equal, the type and link indexes are deleted, and the log is replayed to create new indexes.

The secret-stack init process doesn't support async work, which this unfortunately requires. To solve that, I exposed SSB via a `getSSB()` method on the sbot object. `bin.js` then uses that to run the rebuild, as does patchwork.

Previously, rebuild happened before plugins were added. Now, it happens after. This could create problems for any plugin which relies on the type or link indexes during init. Blobs and gossip both do.
@dominictarr how should we solve this?