### PR TITLE
tidy/refactor: clean up gossip controls

### DIFF
--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -5,35 +5,15 @@ var toAddress = require('../lib/util').toAddress
 var nonPrivate = require('non-private-ip')
 var u = require('../lib/util')
 
-function all(stream, cb) {
-  if (cb) return pull(stream, pull.collect(cb))
-  else return function (cb) {
-    pull(stream, pull.collect(cb))
-  }
-}
-
-function isString(s) {
-  return 'string' === typeof s
-}
-
-function isFunction (f) {
-  return 'function' === typeof f
-}
-
 var isArray = Array.isArray
-
-function isObject (o) {
-  return o && 'object' === typeof o
-}
 
 function rand(array) {
   return array[~~(Math.random()*array.length)]
 }
 
-function sameHost(e) {
-  return function (p) {
-      return p.host == e.host && p.port == e.port
-    }
+function add(ary, item) {
+  if(!~ary.indexOf(item)) ary.push(item)
+  return ary
 }
 
 module.exports = {
@@ -43,19 +23,13 @@ module.exports = {
     seeds: 'async',
     peers: 'sync',
     connect: 'async',
-    changes: 'source'
+    changes: 'source',
+    add: 'sync'
   },
   init: function (server, config) {
-    var sched
-    server.on('close', function () {
-      server.closed = true
-      clearTimeout(sched)
-    })
-
     var notify = Notify()
     var conf = config.gossip || {}
-    var host = config.host || nonPrivate.private() || 'localhost'
-    var port = config.port
+    var home = u.toAddress(server.getAddress())
 
     // Peer Table
     // ==========
@@ -64,110 +38,12 @@ module.exports = {
     var peers = []
     // ordered list of peers to sync with once at startup
     var init_synclist = []
+
     function getPeer(id) {
       return u.find(peers.filter(Boolean), function (e) {
         return e.id === id
       })
     }
-
-    // track connection-state in peertable
-    // :TODO: need to update on rpc.on('closed') ?
-    server.on('rpc:connect', function (rpc) {
-      //************************************
-      //TODO. DISTINGUISH CLIENT CONNECTIONS.
-
-      //don't track cli/web client connections
-      if(rpc.auth.type === 'client') return
-
-      var peer = rpc._peer
-      if(!peer) //incomming connection...
-        peer = getPeer(rpc.id)
-      if(peer) {
-        peer.id = rpc.id
-        peer.connected = true
-
-        notify({ type: 'connect', peer: peer })
-        rpc.on('closed', function () {
-          notify({ type: 'disconnect', peer: peer })
-        })
-      }
-    })
-
-    // populate peertable with configured seeds
-    var seeds = config.seeds
-    seeds = (isArray(seeds)  ? seeds : [seeds])
-    seeds.forEach(function (e) {
-      if(!e) return
-      var p = toAddress(e)
-      if(p && p.key) {
-        peers.push(p)
-        notify({ type: 'discover', peer: p, source: 'seed' })
-      }
-    })
-
-    // populate peertable with pub announcements on the feed
-
-    //TODO! pubs posts must contain public keys.
-    pull(
-      server.messagesByType({type: 'pub', live: true, keys: false, onSync: onFeedSync }),
-      pull.map(function (e) {
-        var o = toAddress(e.content.address)
-        o.announcers = [e.author] // track who has announced this pub addr
-        return o
-      }),
-      pull.filter(function (e) {
-        // filter out announcements for this node
-        if(e.port == port) {
-          if(e.host == host) return false
-          if(e.host == '127.0.0.1' || e.host == 'localhost') return false
-        }
-        if(!e.key) return false
-        return true
-      }),
-      pull.drain(function (e) {
-        var f = u.find(peers, sameHost(e))
-        if(!f) {
-          // new pub
-          peers.push(e)
-          notify({ type: 'discover', peer: e, source: 'pub' })
-        } else {
-          // existing pub, update the announcers list
-          if (!f.announcers)
-            f.announcers = e.announcers
-          else if (f.announcers.indexOf(e.announcers[0]) === -1)
-            f.announcers.push(e.announcers[0])
-        }
-      })
-    )
-    function onFeedSync () {
-      // create the initial synclist, ordered by # of announcers
-      init_synclist = peers.slice()
-      init_synclist.sort(function (a, b) {
-        var al = (a.announcers) ? a.announcers.length : 5
-        var bl = (b.announcers) ? b.announcers.length : 5
-        return bl - al
-      })
-      init_synclist = init_synclist.slice(0, 50) // limit to top 50
-      // kick off a connection
-      connect()
-    }
-
-    // populate peertable with announcements on the LAN multicast
-    server.on('local', function (_peer) {
-      var peer = getPeer(_peer.id)
-      if(!peer) {
-        notify({ type: 'discover', peer: peer, source: 'local' })
-        peers.push(_peer)
-      } else {
-        // peer host could change while in use.
-        // currently, there is a DoS vector here
-        // (someone could falsely advertise your id,
-        // but they could not steal they need private key)
-        // since this is only over local network, it's not a big vector.
-        peer.host = _peer.host
-        peer.port = _peer.port
-      }
-    })
 
     // RPC api
     // =======
@@ -182,80 +58,161 @@ module.exports = {
           return cb(new Error('first param must be an address'))
 
         if(!addr.key) return cb(new Error('address must have ed25519 key'))
-        // find the peer
-        var p = u.find(peers.filter(Boolean), function (e) {
-          return e.host === addr.host && e.port === addr.port
-        })
-        if (!p) // only connect to known peers
-          return cb(new Error('address not a known peer'))
-
-        connectTo(p)
-        cb()
+        // add peer to the table, incase it isn't already.
+        gossip.add(addr, 'manual')
+        connect(addr, cb)
       },
       changes: function () {
         return notify.listen()
+      },
+      //add an address to the peer table.
+      add: function (addr, source) {
+        if(!addr) return
+        addr = u.toAddress(addr)
+
+        // check that this is a valid address, and not pointing at self.
+        if(addr.key === home.key) return
+        if(addr.host === home.host && addr.port === home.port) return
+
+        var f = u.find(peers, function (a) {
+          return (
+            addr.port === a.port
+            && addr.host === a.host
+            && addr.key === a.key
+          )
+        })
+        if(!f) {
+          // new peer
+          peers.push(addr)
+          notify({ type: 'discover', peer: addr, source: source || 'manual' })
+          return true
+        } else {
+          // existing pub, update the announcers list
+          if (!f.announcers)
+            f.announcers = addr.announcers || []
+          else if(addr.announcers[0])
+            add(f.announcers, addr.announcers[0])
+          return false
+        }
+      }
+    }
+
+    // TODO: Move this to another plugin.
+    // not really about gossip.
+    // track connection-state in peertable
+    // :TODO: need to update on rpc.on('closed') ?
+    server.on('rpc:connect', function (rpc) {
+      //************************************
+      //TODO. DISTINGUISH CLIENT CONNECTIONS.
+
+      var peer = getPeer(rpc.id)
+
+      if(peer) {
+        peer.id = rpc.id
+        peer.connected = true
+
+        notify({ type: 'connect', peer: peer })
+        rpc.on('closed', function () {
+          notify({ type: 'disconnect', peer: peer })
+        })
+      }
+    })
+
+    // populate peertable with configured seeds (mainly used in testing)
+    var seeds = config.seeds
+    seeds = (isArray(seeds)  ? seeds : [seeds])
+    seeds.forEach(function (addr) { gossip.add(addr, 'seed') })
+
+    // populate peertable with pub announcements on the feed
+    pull(
+      server.messagesByType({
+        type: 'pub', live: true, keys: false, onSync: onFeedSync
+      }),
+      pull.drain(function (msg) {
+        var addr = toAddress(msg.content.address)
+        addr.announcers = [msg.author] // track who has announced this pub addr
+        gossip.add(addr, 'pub')
+      })
+    )
+
+    function onFeedSync () {
+      // create the initial synclist, ordered by # of announcers
+      init_synclist = peers.slice()
+      init_synclist.sort(function (a, b) {
+        var al = (a.announcers) ? a.announcers.length : 5
+        var bl = (b.announcers) ? b.announcers.length : 5
+        return bl - al
+      })
+      init_synclist = init_synclist.slice(0, 50) // limit to top 50
+      // kick off a connection
+      immediate()
+    }
+
+    // populate peertable with announcements on the LAN multicast
+    server.on('local', function (_peer) {
+      gossip.add(_peer, 'local')
+    })
+
+    function createSchedule (min, max, job) {
+      var sched
+      server.once('close', function () { clearTimeout(sched) })
+      return function schedule () {
+        if(server.closed) return
+        sched = setTimeout(job, min + (Math.random()*max))
+        return schedule
       }
     }
 
     // Gossip
     // ======
+    // create a new connection every so often.
 
-    ;(function schedule() {
-
+    function immediate () {
       if(server.closed) return
-      var timeout = Math.max(config.timeout||0, 1000)
-      var delay = ~~(timeout/2 + Math.random()*timeout)
-      if (init_synclist)
-        delay = ~~(Math.random()*1000) // dont wait long to poll, we're still in our initial sync
+      if(count < (conf.connections || 2)) schedule()
+      var p = choosePeer(); p && connect(p, function () {})
+    }
 
-      sched = setTimeout(function () {
-        schedule(); connect()
-      }, delay)
-    })()
+    var schedule = createSchedule(1e3, config.timeout || 2e3, immediate)()
 
-    server.once('close', function () { clearTimeout(sched) })
+  /*
+    ideas:
+
+      if long time since replicated then priority = high
+      if syncing_complete and contacted_all_pubs then rereplicate
+      if popular_pub and long_time_sincethen priority=high
+      if posted_recently > connected_recently then priority=high
+      if failed_recently then priority=low
+
+  */
 
     var count = 0
 
-    function connect () {
-      if(server.closed) return
+    function choosePeer () {
+      if(init_synclist.length) return init_synclist.shift()
 
-      //two concurrent connections.
-      if(count >= (conf.connections || 2)) return
+      // connect to this random peer
+      // choice is weighted...
+      // - decrease odds due to failures
+      // - increase odds due to multiple announcements
+      // - if no announcements, it came from config seed or LAN, so given a higher-than-avg weight
 
-      var p
-      if (init_synclist) {
-        // initial sync, take next in the ordered list
-        p = init_synclist.shift()
-        if (init_synclist.length === 0)
-          init_synclist = null
-      }
-      else {
-        // connect to this random peer
-        // choice is weighted...
-        // - decrease odds due to failures
-        // - increase odds due to multiple announcements
-        // - if no announcements, it came from config seed or LAN, so given a higher-than-avg weight
-        var default_a = 5 // for seeds and peers (with no failures, lim will be 0.75)
-        p = rand(peers.filter(function (e) {
-          var a = Math.min((e.announcers) ? e.announcers.length : default_a, 10) // cap at 10
-          var f = e.failure || 0
-          var lim = (a+10)/((f+1)*20)
-          // this function increases linearly from 0.5 to 1 with # of announcements
-          // ..and decreases by inversely with # of failures
-          return !e.connected && (Math.random() < lim)
-        }))
-      }
+      // for seeds and peers (with no failures, lim will be 0.75)
+      var default_a = 5
+      var p = rand(peers.filter(function (e) {
+        var a = Math.min((e.announcers) ? e.announcers.length : default_a, 10) // cap at 10
+        var f = e.failure || 0
+        var lim = (a+10)/((f+1)*20)
+        // this function increases linearly from 0.5 to 1 with # of announcements
+        // ..and decreases by inversely with # of failures
+        return !e.connected && (Math.random() < lim)
+      }))
 
-      if(p) {
-        connectTo(p, function (err, rpc) {
-          if(err) return console.error(err)
-        })
+      return p
 
-      }
     }
 
-    function connectTo (p, cb) {
+    function connect (p, cb) {
       count ++
       p.time = p.time || {}
       if (!p.time.connect)
@@ -266,7 +223,6 @@ module.exports = {
       server.connect(p, function (err, rpc) {
         if(err) return (cb && cb(err))
 
-        rpc._peer = p
         p.id = rpc.id
         p.time = p.time || {}
         p.time.connect = Date.now()


### PR DESCRIPTION
this is a refactor of the gossip plugin. code was deduplicated, and concerns separated.
for example, there was `connect` which chose a peer to connect to, and then called `connectTo` which actually connected to it. refactored so to have a choosePeer function and then a connect function.

I want to take this towards separating the strict parts which can be easily tested (adding a peer, etc)
from the fuzzy parts (choosing which peer to connect to, etc)

I think we do a similar thing with blobs.