### PR TITLE
fix: replicate plugin now returns api during init, as intended

### DIFF
--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -115,12 +115,12 @@ module.exports = {
           sbot.emit('replicate:finish', progress)
         }
       })
-
-      return {
-        changes: function () {
-          return notify.listen()
-        }
-      }
     })
+    
+    return {
+      changes: function () {
+        return notify.listen()
+      }
+    }
   }
 }


### PR DESCRIPTION
quick simple bugfix