### PR TITLE
update peer-state and log when gossip connections fail

### DIFF
--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -227,6 +227,7 @@ module.exports = {
       server.connect(p, function (err, rpc) {
         if (err) {
           p.connected = false
+          notify({ type: 'connect-failure', peer: p })
           server.emit('log:info', ['SBOT', p.host+':'+p.port+p.key, 'connection failed', err])
           return (cb && cb(err))
         }

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -224,7 +224,11 @@ module.exports = {
       p.connected = true
 
       server.connect(p, function (err, rpc) {
-        if(err) return (cb && cb(err))
+        if (err) {
+          p.connected = false
+          server.emit('log:info', ['SBOT', p.host+':'+p.port+p.key, 'connection failed', err])
+          return (cb && cb(err))
+        }
 
         p.id = rpc.id
         p.time = p.time || {}

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -41,7 +41,7 @@ module.exports = {
 
     function getPeer(id) {
       return u.find(peers.filter(Boolean), function (e) {
-        return e.id === id
+        return e.key === id
       })
     }
 
@@ -68,6 +68,7 @@ module.exports = {
       //add an address to the peer table.
       add: function (addr, source) {
         if(!addr) return
+
         addr = u.toAddress(addr)
         if(!u.isAddress(addr))
           throw new Error('not a valid address:' + JSON.stringify(addr))
@@ -109,7 +110,7 @@ module.exports = {
 
       var peer = getPeer(rpc.id)
 
-      if(peer) {
+      if (peer) {
         peer.id = rpc.id
         peer.connected = true
 


### PR DESCRIPTION
This was causing peers in the sync page to appear to be connecting, when, in reality, the connection attempt had failed