### PR TITLE
replication back pressure

### DIFF
--- a/api.md
+++ b/api.md
@@ -287,7 +287,6 @@ getAddress(cb)
 
 
 
-
 ## getLatest: async
 
 Get the latest message in the database by the given feedid.
@@ -313,6 +312,22 @@ latest
 ```js
 latest()
 ```
+
+
+
+## latestSequence: async
+
+Get the sequence and local timestamp of the last received message from
+a given `feedId`.
+
+```bash
+latestSequence {feedId}
+```
+
+```js
+latest({feedId})
+```
+
 
 
 ## whoami: sync

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function usage (cmd) {
     return Object.keys(apidocs).map(function (name) {
       if (name == '_')
         return mdm.usage(apidocs[name], null, { nameWidth: 20 })
-      
+
       var text = mdm.usage(apidocs[name], null, { prefix: name, nameWidth: 20 })
       return text.slice(text.indexOf('Commands:') + 10) // skip past the toplevel summary, straight to the cmd list
     }).join('\n\n')
@@ -100,6 +100,7 @@ var SSB = {
       getPublicKey             : ssb.getPublicKey,
       latest                   : ssb.latest,
       getLatest                : valid.async(ssb.getLatest, 'feedId'),
+      latestSequence           : valid.async(ssb.latestSequence, 'feedId'),
       createFeed               : ssb.createFeed,
       whoami                   : function () { return { id: feed.id } },
       relatedMessages          : valid.async(ssb.relatedMessages, 'relatedMessagesOpts'),
@@ -112,7 +113,7 @@ var SSB = {
       sublevel                 : ssb.sublevel,
       messagesByType           : valid.source(ssb.messagesByType, 'string|messagesByTypeOpts'),
       createWriteStream        : ssb.createWriteStream,
-      createLatestLookupStream : ssb.createLatestLookupStream,
+//      createLatestLookupStream : ssb.createLatestLookupStream,
     }
   }
 }

--- a/plugins/block.js
+++ b/plugins/block.js
@@ -14,7 +14,7 @@ exports.init = function (sbot) {
 
   //if a currently connected peer is blocked, disconnect them immediately.
   pull(
-    sbot.friends.createFriendStream({graph: 'flag'}),
+    sbot.friends.createFriendStream({graph: 'flag', live: true}),
     pull.drain(function (blocked) {
       if(sbot.peers[blocked]) {
         sbot.peers[blocked].forEach(function (b) {

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -83,6 +83,7 @@ exports.init = function (sbot, config) {
 
     createFriendStream: valid.source(function (opts) {
       opts = opts || {}
+      var live = opts.live === true
       var start = opts.start || sbot.id
       var graph = graphs[opts.graph || 'follow']
       if(!graph)
@@ -105,7 +106,7 @@ exports.init = function (sbot, config) {
         }
       })
 
-      if(!opts.live) { cancel(); ps.end() }
+      if(!live) { cancel(); ps.end() }
 
       return ps
     }, 'createFriendStreamOpts?'),

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -62,6 +62,7 @@ exports.init = function (sbot, config) {
   }))
 
   return {
+
     get: valid.sync(function (opts) {
       var g = graphs[opts.graph || 'follow']
       if(!g) throw new Error('opts.graph must be provided')
@@ -99,10 +100,13 @@ exports.init = function (sbot, config) {
         start: start,
         hops: opts.hops || conf.hops || 3,
         max: opts.dunbar || conf.dunbar || 150,
-        each: function (_, to) {
+        each: function (_, to, hops) {
           if(to !== start) ps.push(to)
         }
       })
+
+      if(!opts.live) { cancel(); ps.end() }
+
       return ps
     }, 'createFriendStreamOpts?'),
 

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -84,6 +84,7 @@ exports.init = function (sbot, config) {
     createFriendStream: valid.source(function (opts) {
       opts = opts || {}
       var live = opts.live === true
+      var meta = opts.meta === true
       var start = opts.start || sbot.id
       var graph = graphs[opts.graph || 'follow']
       if(!graph)
@@ -92,9 +93,13 @@ exports.init = function (sbot, config) {
         cancel && cancel()
       })
 
+      function push (to, hops) {
+        return ps.push(meta ? {id: to, hops: hops} : to)
+      }
+
       //by default, also emit your own key.
       if(opts.self !== false)
-        ps.push(start)
+        push(start, 0)
 
       var conf = config.friends || {}
       cancel = graph.traverse({
@@ -102,7 +107,7 @@ exports.init = function (sbot, config) {
         hops: opts.hops || conf.hops || 3,
         max: opts.dunbar || conf.dunbar || 150,
         each: function (_, to, hops) {
-          if(to !== start) ps.push(to)
+          if(to !== start) push(to, hops)
         }
       })
 

--- a/plugins/friends.md
+++ b/plugins/friends.md
@@ -40,14 +40,15 @@ hops(start, graph, { dunbar:, hops: }, cb)
 
 ## createFriendStream: source
 
-Live-stream the ids of feeds which meet the given hops query.
+Live-stream the ids of feeds which meet the given hops query. If `meta`
+option is set, then will return steam of `{id, hops}`
 
 ```bash
-createFriendStream [--start feedid] [--graph follow|flag] [--dunbar number] [--hops number]
+createFriendStream [--start feedid] [--graph follow|flag] [--dunbar number] [--hops number] [--meta]
 ```
 
 ```js
-createFriendStream({ start:, graph:, dunbar:, hops: }, cb)
+createFriendStream({ start:, graph:, dunbar:, hops: , meta: }, cb)
 ```
 
  - `start` (FeedID, default: local user): Which feed to start from.

--- a/test/friends.js
+++ b/test/friends.js
@@ -2,12 +2,15 @@ var ssbKeys = require('ssb-keys')
 var cont    = require('cont')
 var tape    = require('tape')
 var u       = require('./util')
+var pull    = require('pull-stream')
+
 // create 3 feeds
 // add some of friend edges (follow, flag)
 // make sure the friends plugin analyzes correctly
 
 var createSbot = require('../')
   .use(require('../plugins/friends'))
+
 
 tape('construct and analyze graph', function (t) {
 
@@ -23,67 +26,88 @@ tape('construct and analyze graph', function (t) {
   var bob = sbot.createFeed()
   var carol = sbot.createFeed()
 
-  cont.para([
-    alice.add({
-      type: 'contact', contact: bob.id,
-      following: true,
-      flagged: { reason: 'foo' }
-    }),
-    alice.add(u.follow(carol.id)),
-    bob.add(u.follow(alice.id)),
-    bob.add({
-      type: 'contact', contact: carol.id,
-      following: false, flagged: true
-    }),
-    carol.add(u.follow(alice.id))
-  ]) (function (err, results) {
-    if(err) throw err
+  t.test('add friends, and retrive all friends for a peer', function (t) {
 
     cont.para([
-      cont(sbot.friends.all)(),
-      cont(sbot.friends.all)('follow'),
-      cont(sbot.friends.all)('flag'),
-
-      cont(sbot.friends.hops)(alice.id),
-      cont(sbot.friends.hops)(alice.id, 'follow'),
-      cont(sbot.friends.hops)(alice.id, 'flag'),
-
-      cont(sbot.friends.hops)(bob.id, 'follow'),
-      cont(sbot.friends.hops)(bob.id, 'flag'),
-
-      cont(sbot.friends.hops)(carol.id, 'follow'),
-      cont(sbot.friends.hops)(carol.id, 'flag')
-    ], function (err, results) {
+      alice.add({
+        type: 'contact', contact: bob.id,
+        following: true,
+        flagged: { reason: 'foo' }
+      }),
+      alice.add(u.follow(carol.id)),
+      bob.add(u.follow(alice.id)),
+      bob.add({
+        type: 'contact', contact: carol.id,
+        following: false, flagged: true
+      }),
+      carol.add(u.follow(alice.id))
+    ]) (function (err, results) {
       if(err) throw err
 
-      var aliasMap = {}
-      aliasMap[alice.id] = 'alice'
-      aliasMap[bob.id]   = 'bob'
-      aliasMap[carol.id] = 'carol'
+      cont.para([
+        cont(sbot.friends.all)(),
+        cont(sbot.friends.all)('follow'),
+        cont(sbot.friends.all)('flag'),
 
-      a = toAliases(aliasMap)
+        cont(sbot.friends.hops)(alice.id),
+        cont(sbot.friends.hops)(alice.id, 'follow'),
+        cont(sbot.friends.hops)(alice.id, 'flag'),
 
-      results = results.map(a)
-      var i = 0
+        cont(sbot.friends.hops)(bob.id, 'follow'),
+        cont(sbot.friends.hops)(bob.id, 'flag'),
 
-      t.deepEqual(results[i++], { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
-      t.deepEqual(results[i++], { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
-      t.deepEqual(results[i++], { alice: { bob: { reason: 'foo' } }, bob: { carol: true }, carol: {} })
+        cont(sbot.friends.hops)(carol.id, 'follow'),
+        cont(sbot.friends.hops)(carol.id, 'flag')
+      ], function (err, results) {
+        if(err) throw err
 
-      t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 1 })
-      t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 1 })
-      t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 2 })
+        var aliasMap = {}
+        aliasMap[alice.id] = 'alice'
+        aliasMap[bob.id]   = 'bob'
+        aliasMap[carol.id] = 'carol'
 
-      t.deepEqual(results[i++], { bob: 0, alice: 1, carol: 2 })
-      t.deepEqual(results[i++], { bob: 0, carol: 1 })
+        a = toAliases(aliasMap)
 
-      t.deepEqual(results[i++], { carol: 0, alice: 1, bob: 2 })
-      t.deepEqual(results[i++], { carol: 0 })
+        results = results.map(a)
+        var i = 0
 
-      t.end()
-      sbot.close()
+        t.deepEqual(results[i++], { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
+        t.deepEqual(results[i++], { alice: { bob: true, carol: true }, bob: { alice: true }, carol: { alice: true } })
+        t.deepEqual(results[i++], { alice: { bob: { reason: 'foo' } }, bob: { carol: true }, carol: {} })
+
+        t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 1 })
+        t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 1 })
+        t.deepEqual(results[i++], { alice: 0, bob: 1, carol: 2 })
+
+        t.deepEqual(results[i++], { bob: 0, alice: 1, carol: 2 })
+        t.deepEqual(results[i++], { bob: 0, carol: 1 })
+
+        t.deepEqual(results[i++], { carol: 0, alice: 1, bob: 2 })
+        t.deepEqual(results[i++], { carol: 0 })
+
+        t.end()
+      })
     })
   })
+
+  t.test('creatFriendStream', function () {
+    pull(
+      sbot.friends.createFriendStream(),
+      pull.collect(function (err, ary) {
+        t.notOk(err)
+        console.log(ary)
+        t.equal(ary.length, 3)
+        t.deepEqual(ary.sort(), [alice.id, bob.id, carol.id].sort())
+        t.end()
+      })
+    )
+  })
+
+  t.test('cleanup', function (t) {
+    sbot.close()
+    t.end()
+  })
+
 })
 
 tape('correctly delete edges', function (t) {
@@ -100,68 +124,149 @@ tape('correctly delete edges', function (t) {
   var bob   = sbot.createFeed()
   var carol = sbot.createFeed()
 
-  cont.para([
-    alice.add({
-      type:'contact', contact:bob.id,
-      following: true, flagged: true
-    }),
-    alice.add(u.follow(carol.id)),
-    bob.add(u.follow(alice.id)),
-    bob.add({
-      type: 'contact', contact: carol.id,
-      following: false, flagged: { reason: 'foo' }
-    }),
-    carol.add(u.follow(alice.id)),
-    alice.add({
-      type:'contact', contact: carol.id,
-      following: false,  flagged: true
-    }),
-    alice.add({
-      type:'contact', contact: bob.id,
-      following: true,  flagged: false
-    }),
-    bob.add(u.unfollow(carol.id))
-  ]) (function () {
+  t.test('add and delete', function (t) {
 
     cont.para([
-      cont(sbot.friends.all)('follow'),
-      cont(sbot.friends.all)('flag'),
+      alice.add({
+        type:'contact', contact:bob.id,
+        following: true, flagged: true
+      }),
+      alice.add(u.follow(carol.id)),
+      bob.add(u.follow(alice.id)),
+      bob.add({
+        type: 'contact', contact: carol.id,
+        following: false, flagged: { reason: 'foo' }
+      }),
+      carol.add(u.follow(alice.id)),
+      alice.add({
+        type:'contact', contact: carol.id,
+        following: false,  flagged: true
+      }),
+      alice.add({
+        type:'contact', contact: bob.id,
+        following: true,  flagged: false
+      }),
+      bob.add(u.unfollow(carol.id))
+    ]) (function () {
 
-      cont(sbot.friends.hops)(alice.id, 'follow'),
-      cont(sbot.friends.hops)(alice.id, 'flag'),
+      cont.para([
+        cont(sbot.friends.all)('follow'),
+        cont(sbot.friends.all)('flag'),
 
-      cont(sbot.friends.hops)(bob.id, 'follow'),
-      cont(sbot.friends.hops)(bob.id, 'flag'),
+        cont(sbot.friends.hops)(alice.id, 'follow'),
+        cont(sbot.friends.hops)(alice.id, 'flag'),
 
-      cont(sbot.friends.hops)(carol.id, 'follow'),
-      cont(sbot.friends.hops)(carol.id, 'flag')
-    ], function (err, results) {
+        cont(sbot.friends.hops)(bob.id, 'follow'),
+        cont(sbot.friends.hops)(bob.id, 'flag'),
 
-      var aliasMap = {}
-      aliasMap[alice.id] = 'alice'
-      aliasMap[bob.id]   = 'bob'
-      aliasMap[carol.id] = 'carol'
-      a = toAliases(aliasMap)
+        cont(sbot.friends.hops)(carol.id, 'follow'),
+        cont(sbot.friends.hops)(carol.id, 'flag')
+      ], function (err, results) {
 
-      results = results.map(a)
-      var i = 0
+        var aliasMap = {}
+        aliasMap[alice.id] = 'alice'
+        aliasMap[bob.id]   = 'bob'
+        aliasMap[carol.id] = 'carol'
+        a = toAliases(aliasMap)
 
-      t.deepEqual(results[i++], { alice: { bob: true }, bob: { alice: true }, carol: { alice: true } })
-      t.deepEqual(results[i++],  { alice: { carol: true }, bob: { carol: { reason: 'foo' }}, carol: {} })
+        results = results.map(a)
+        var i = 0
 
-      t.deepEqual(results[i++], { alice: 0, bob: 1 })
-      t.deepEqual(results[i++], { alice: 0, carol: 1 })
+        t.deepEqual(results[i++], { alice: { bob: true }, bob: { alice: true }, carol: { alice: true } })
+        t.deepEqual(results[i++],  { alice: { carol: true }, bob: { carol: { reason: 'foo' }}, carol: {} })
 
-      t.deepEqual(results[i++], { bob: 0, alice: 1 })
-      t.deepEqual(results[i++], { bob: 0, carol: 1 })
+        t.deepEqual(results[i++], { alice: 0, bob: 1 })
+        t.deepEqual(results[i++], { alice: 0, carol: 1 })
 
-      t.deepEqual(results[i++], { carol: 0, alice: 1, bob: 2 })
-      t.deepEqual(results[i++], { carol: 0 })
+        t.deepEqual(results[i++], { bob: 0, alice: 1 })
+        t.deepEqual(results[i++], { bob: 0, carol: 1 })
 
-      t.end()
-      sbot.close()
+        t.deepEqual(results[i++], { carol: 0, alice: 1, bob: 2 })
+        t.deepEqual(results[i++], { carol: 0 })
+
+        t.end()
+      })
     })
   })
+
+  t.test('createFriendStream after delete', function (t) {
+    pull(
+      sbot.friends.createFriendStream(),
+      pull.collect(function (err, ary) {
+        t.notOk(err)
+        console.log(ary)
+        t.equal(ary.length, 2)
+        t.deepEqual(ary.sort(), [alice.id, bob.id].sort())
+        t.end()
+      })
+    )
+  })
+
+  t.test('cleanup', function (t) {
+    sbot.close()
+    t.end()
+  })
+
+})
+
+tape('indirect friends', function (t) {
+
+  var aliceKeys = ssbKeys.generate()
+
+  var sbot = createSbot({
+      temp:'test-friends3',
+      port: 45452, host: 'localhost', timeout: 1000,
+      keys: aliceKeys
+    })
+
+  var alice = sbot.createFeed(aliceKeys)
+  var bob   = sbot.createFeed()
+  var carol = sbot.createFeed()
+  var dan   = sbot.createFeed()
+
+  t.test('chain of friends', function (t) {
+    cont.para([
+      alice.add(u.follow(bob.id)),
+      bob.add(u.follow(carol.id)),
+      carol.add(u.follow(dan.id))
+    ]) (function (err, results) {
+      if(err) throw err
+
+      sbot.friends.hops({hops: 3}, function (err, all) {
+        if(err) throw err
+        console.log(all)
+        var o = {}
+
+        o[alice.id] = 0
+        o[bob.id]   = 1
+        o[carol.id] = 2
+        o[dan.id]   = 3
+
+        t.deepEqual(all, o)
+
+        t.end()
+      })
+    })
+  })
+
+  t.test('createFriendStream on long chain', function (t) {
+
+    pull(
+      sbot.friends.createFriendStream(),
+      pull.collect(function (err, ary) {
+        if(err) throw err
+        console.log(ary)
+        t.end()
+      })
+    )
+
+  })
+
+  t.test('cleanup', function (t) {
+    sbot.close()
+    t.end()
+  })
+
 })
 
 function toAliases(aliasMap) {

--- a/test/random.js
+++ b/test/random.js
@@ -18,6 +18,10 @@ function bar (prog) {
   return s + ' '+prog.progress+'/'+prog.total+':'+prog.feeds
 }
 
+function isNumber (n) {
+  return typeof n === 'number'
+}
+
 var createSbot = require('../')
   .use(require('../plugins/friends'))
   .use(require('../plugins/replicate'))
@@ -95,7 +99,7 @@ function latest (sbot, cb) {
     for(var k in keys) (function (key) {
       n++
       get(key, function (err, value) {
-        map[key] = value
+        map[key] = isNumber(value) ? value : value.sequence
         if(--n) return
         cb(null, map)
       })


### PR DESCRIPTION
This applies a simple algorithm to ensuring that peers do not publish too much at once.
peers accept anything from someone they follow, but only 100 items (default) per day from indirect peers.

this depends on some small breaking changes to secure-scuttlebutt