### PR TITLE
fix validation: .previous is optional in messages (add())

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -54,7 +54,7 @@ module.exports = valid({
       return MissingAttr(n, 'sequence', 'number')
 
     // .previous
-    if (!ref.isMsg(v.previous))
+    if (v.previous && !ref.isMsg(v.previous))
       return MissingAttr(n, 'previous', 'msgId')
 
     // .timestamp


### PR DESCRIPTION
`.add()` was incorrectly always expecting `.previous`. This makes it optional.