### PR TITLE
Handle IPv6 addresses

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -73,10 +73,11 @@ exports.merge = function (a, b) {
 exports.parseAddress = function (e) {
   if(isString(e)) {
     var parts = e.split(':')
+    var id = parts.pop(), port = parts.pop(), host = parts.join(':')
     var e = {
-      host: parts[0],
-      port: +(parts[1] || DEFAULT_PORT),
-      key: parts[2]
+      host: host,
+      port: +(port || DEFAULT_PORT),
+      key: id
     }
     return e
   }

--- a/plugins/invite.js
+++ b/plugins/invite.js
@@ -8,6 +8,7 @@ var ip = require('ip')
 var mdm = require('mdmanifest')
 var valid = require('../lib/validators')
 var apidoc = require('../lib/apidocs').invite
+var u = require('../lib/util')
 //okay this plugin adds a method
 //invite(seal({code, public})
 
@@ -48,7 +49,7 @@ module.exports = {
     return {
       create: valid.async(function (n, cb) {
         var addr = server.getAddress()
-        var host = addr.split(':')[0]
+        var host = u.toAddress(addr).host
         if(!config.allowPrivate && (
           ip.isPrivate(host) || 'localhost' === host)
         )

--- a/test/invite.js
+++ b/test/invite.js
@@ -168,3 +168,39 @@ tape('test invite.accept doesnt follow if already followed', function (t) {
     })
   })
 })
+
+tape('test invite.accept api with ipv6', function (t) {
+
+  var alice = createSbot({
+    temp: 'test-invite-alice4', timeout: 100,
+    allowPrivate: true,
+    keys: ssbKeys.generate()
+  })
+
+  var bob = createSbot({
+    temp: 'test-invite-bob4', timeout: 100,
+    keys: ssbKeys.generate()
+  })
+
+  alice.invite.create(1, function (err, invite) {
+    if(err) throw err
+
+    // use a local ipv6 address in the invite
+    var inviteV6 = invite.replace(/^[0-9.]*/, '::1')
+    console.log(inviteV6)
+
+    bob.invite.accept(inviteV6, function (err) {
+      if(err) throw err
+      alice.friends.hops({
+        source: alice.id, dest: bob.id
+      }, function (err, hops) {
+        if(err) throw err
+        t.equal(hops[bob.id], 1, 'alice follows bob')
+        alice.close(true)
+        bob.close(true)
+        t.end()
+      })
+    })
+  })
+
+})


### PR DESCRIPTION
This patch updates scuttlebot to correctly parse addresses with IPv6 hostnames, as in
https://github.com/ssbc/ssb-ref/commit/3e68d06149e19847e8bcb6ea8975c9227ca555c5 and
https://github.com/ssbc/ssb-ref/commit/8d5f7c3badc8e5fc48090e384d8fa5458619a0f7