### PR TITLE
Nicer logging

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -61,7 +61,14 @@ require('ssb-client')(keys, {manifest: manifest,
   port: config.port, host: config.host||'localhost',
   key: keys.id
 }, function (err, rpc) {
-  if(err) throw err
+  if(err) {
+    if (/could not connect/.test(err.message)) {
+      console.log('Error: Could not connect to the scuttlebot server.')
+      console.log('Use the "server" command to start it.')
+      process.exit(1)
+    }
+    throw err
+  }
 
   // add aliases
   for (var k in cmdAliases) {

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -304,7 +304,7 @@ module.exports = {
           count = Math.max(count - 1, 0)
           //or how many failures there have been.
           p.connected = false
-          server.emit('log:info', ['SBOT', rpc._sessid, 'disconnect'])
+          server.emit('log:info', ['SBOT', rpc.id, 'disconnect'])
 
           var fail = !p.time || (p.time.attempt > p.time.connect)
 

--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -290,7 +290,7 @@ module.exports = {
           p.connected = false
           p.failure = (p.failure || 0) + 1
           notify({ type: 'connect-failure', peer: p })
-          server.emit('log:info', ['SBOT', p.host+':'+p.port+p.key, 'connection failed', err])
+          server.emit('log:info', ['SBOT', p.host+':'+p.port+p.key, 'connection failed', err.message || err])
           schedule()
           return (cb && cb(err))
         }

--- a/plugins/invite.js
+++ b/plugins/invite.js
@@ -103,7 +103,7 @@ module.exports = {
             //this is not a big enough deal to fix though.
 
             codesDB.put(rpc.id, invite, function (err) {
-              server.emit('log:info', ['invite', rpc._sessid, 'use', req])
+              server.emit('log:info', ['invite', rpc.id, 'use', req])
 
               server.publish({
                 type: 'contact',

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -42,6 +42,7 @@ function formatter(id, level) {
 module.exports = function logging (server) {
   var id = server.id
   server.on('log:info',    formatter(id, color.green('info')))
+  server.on('log:notice',  formatter(id, color.blue('note')))
   server.on('log:warning', formatter(id, color.yellow('warn')))
   server.on('log:error',   formatter(id, color.red('err!')))
 }

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -1,5 +1,13 @@
 var color = require('bash-color')
 
+var LOG_LEVELS = [
+  'error',
+  'warning',
+  'notice',
+  'info'
+]
+var DEFAULT_LEVEL = LOG_LEVELS.indexOf('notice')
+
 function indent (o) {
   return o.split('\n').map(function (e) {
     return '  ' + e
@@ -39,12 +47,24 @@ function formatter(id, level) {
   }
 }
 
-module.exports = function logging (server) {
+module.exports = function logging (server, conf) {
+  var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level) || DEFAULT_LEVEL
+  if (level === -1) {
+    console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)
+    console.log('Should be one of:', LOG_LEVELS.join(', '))
+    level = DEFAULT_LEVEL
+  }
+  console.log('Log level:', LOG_LEVELS[level])
+
   var id = server.id
-  server.on('log:info',    formatter(id, color.green('info')))
-  server.on('log:notice',  formatter(id, color.blue('note')))
-  server.on('log:warning', formatter(id, color.yellow('warn')))
-  server.on('log:error',   formatter(id, color.red('err!')))
+  if (level >= LOG_LEVELS.indexOf('info'))
+    server.on('log:info',    formatter(id, color.green('info')))
+  if (level >= LOG_LEVELS.indexOf('notice'))
+    server.on('log:notice',  formatter(id, color.blue('note')))
+  if (level >= LOG_LEVELS.indexOf('warning'))
+    server.on('log:warning', formatter(id, color.yellow('warn')))
+  if (level >= LOG_LEVELS.indexOf('error'))
+    server.on('log:error',   formatter(id, color.red('err!')))
 }
 
 module.exports.init = module.exports

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -129,7 +129,7 @@ function replicate(sbot, config, rpc, cb) {
           debounce.set()
       }, function (err) {
         if(err)
-          sbot.emit('log:error', ['replication', rep._sessid, 'error', err])
+          sbot.emit('log:error', ['replication', rep.id, 'error', err])
         sources.cap()
       })
     )
@@ -171,16 +171,16 @@ module.exports = {
       //this is the cli client, just ignore.
       if(rpc.id === sbot.id) return
 
-      sbot.emit('log:info', ['replicate', rpc._sessid, 'start', rpc.id])
+      sbot.emit('log:info', ['replicate', rpc.id, 'start'])
       sbot.emit('replicate:start', rpc)
       replicate(sbot, config, rpc, function (err, progress) {
         if(err) {
           sbot.emit('replicate:fail', err)
-          sbot.emit('log:warning', ['replicate', rpc._sessid, 'error', err])
+          sbot.emit('log:warning', ['replicate', rpc.id, 'error', err])
         } else {
           var progressSummary = summarizeProgress(progress)
           if (progressSummary)
-            sbot.emit('log:info', ['replicate', rpc._sessid, 'success', progressSummary])
+            sbot.emit('log:info', ['replicate', rpc.id, 'success', progressSummary])
           sbot.emit('replicate:finish', progress)
         }
       })

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -180,7 +180,7 @@ module.exports = {
         } else {
           var progressSummary = summarizeProgress(progress)
           if (progressSummary)
-            sbot.emit('log:info', ['replicate', rpc.id, 'success', progressSummary])
+            sbot.emit('log:notice', ['replicate', rpc.id, 'success', progressSummary])
           sbot.emit('replicate:finish', progress)
         }
       })


### PR DESCRIPTION
This PR makes a bunch of updates to quite down the logs, significantly.

1. The replication success-report now just tells you how many feeds were updated, and how many new messages there were. If there were no new messages, then nothing is output.
2. All log entries now include the ID of the remote. It previously used `._sessid`, which I think is old code because I dont see any references for it anymore.
3. Connection errors no longer include a stack trace.
4. Added a new log level, 'notice', which is between 'info' and 'warn'. So the full list, in order of most verbose to least, is: info, notice, warn, error.
5. Moved the replication summary to 'notice', and left all other info logging where it was.
5. Added `logging.level` config, which lets you set the verboseness. It defaults to notice, which means info will not be included.

The end-effect is, by default, you only see updates in the log now. If you want to see things like connection events, you can do so with `--logging.level info`.