### PR TITLE
fix CPU spin out on over quota

### DIFF
--- a/plugins/blobs/queue.js
+++ b/plugins/blobs/queue.js
@@ -10,7 +10,8 @@ function isFunction (f) {
   return 'function' === typeof f
 }
 
-function Work(delay, n, label, fun) {
+function Work(avgWait, n, label, fun) {
+  n  = 1
   var doing = 0, timeout
 
   var timers = []
@@ -28,11 +29,13 @@ function Work(delay, n, label, fun) {
     }, d)
     timer.unref()
     timers.push(timer)
+
     return timer
   }
 
   function job () {
     // abort if already doing too many
+
     if(doing >= n) return
     doing++
 
@@ -45,13 +48,13 @@ function Work(delay, n, label, fun) {
       }
 
       // requeue after a delay
-      var wait = ~~(delay/2 + delay*Math.random())
+      var wait = ~~(avgWait/2 + avgWait*Math.random())
       delay(job, wait)
     })
   }
 
   job.abort = function () {
-    timers.forEach(function (timer) { clearTimeout(timer) })
+    timers.forEach(clear)
   }
 
   return job
@@ -78,9 +81,6 @@ function max (jobs, test) {
 module.exports = function (work) {
 
   var jobs = []
-
-  function pull (index) {
-  }
 
   var queue = {
     push: function (job) {
@@ -118,3 +118,10 @@ module.exports = function (work) {
 
   return queue
 }
+
+
+
+
+
+
+

--- a/plugins/blobs/replication.js
+++ b/plugins/blobs/replication.js
@@ -101,6 +101,7 @@ module.exports = function (sbot, opts, notify, quota) {
     if(!hasPeers()) return done()
 
     var job = hasQueue.pull(filter)
+
     if(!job || job.done) return done()
 
     var n = 0, found = false
@@ -207,3 +208,7 @@ module.exports = function (sbot, opts, notify, quota) {
     }
   }
 }
+
+
+
+


### PR DESCRIPTION
It was a really stupid error, had two things named `delay` so it was causing `setTimeout(fn, NaN)` (probably) anyway, cpu levels are now acceptable. 