### PR TITLE
replicate peers on the local network, even if they are strangers

### DIFF
--- a/plugins/gossip.js
+++ b/plugins/gossip.js
@@ -42,7 +42,7 @@ Peers : [{
   announcers: [ID+], // append only set.
                      // (unique members, only adds to end),
                      // could change for {id: true}
-  type: 'pub'|'manual'|'local'
+  source: 'pub'|'manual'|'local'
 }]
 */
 
@@ -116,6 +116,7 @@ module.exports = {
         })
         if(!f) {
           // new peer
+          addr.source = source
           peers.push(addr)
           notify({ type: 'discover', peer: addr, source: source || 'manual' })
           return true

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -88,10 +88,22 @@ function replicate(sbot, config, rpc, cb) {
     var lastDB = sbot.sublevel('lst')
 
     pull(
-      sbot.friends.createFriendStream(opts),
+      cat([
+        sbot.friends.createFriendStream(opts),
+        //include new local peers
+        //so that you can put a name to someone on your local network.
+        pull.values(
+          sbot.gossip.peers()
+          .filter(function (e) { return e.source === 'local' })
+          .map(function (e) { return {id: e.key, hops: 6} })
+        )
+      ]),
       aborter,
-      pull.through(function (s) {
-        to_recv['string' === typeof s ? s  : s.id] = 0
+      pull.filter(function (s) {
+        //sometimes with local peers someone may be seen twice
+        //filter that out (and also keep track of what we expect to receive)
+        var id = 'string' === typeof s ? s  : s.id
+        if(to_recv[id] == null) { to_recv[id] = 0; return true }
       }),
       //lookup the latest message from a given peer.
       para(function (data, cb) {
@@ -210,6 +222,8 @@ function summarizeProgress (progress) {
     return false
   return 'Feeds updated: '+updatedFeeds+', New messages: '+newMessages
 }
+
+
 
 
 

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -89,19 +89,19 @@ function replicate(sbot, config, rpc, cb) {
 
     pull(
       cat([
-        sbot.friends.createFriendStream(opts),
         //include new local peers
         //so that you can put a name to someone on your local network.
         pull.values(
           sbot.gossip.peers()
           .filter(function (e) { return e.source === 'local' })
           .map(function (e) { return {id: e.key, hops: 6} })
-        )
+        ),
+        // include the user's contacts
+        sbot.friends.createFriendStream(opts)
       ]),
       aborter,
       pull.filter(function (s) {
-        //sometimes with local peers someone may be seen twice
-        //filter that out (and also keep track of what we expect to receive)
+        //filter out duplicates, and also keep track of what we expect to receive
         var id = 'string' === typeof s ? s  : s.id
         if(to_recv[id] == null) { to_recv[id] = 0; return true }
       }),


### PR DESCRIPTION
This _should_ replicate strangers you find on the local network, but only the their first 100 messages (by currently hardcoded quotas - easy to change) also it should replicate their avatars.

@mixmix you are more likely to have two computers running pw next to each other, can you test this? 