### PR TITLE
add time measurement to replication summary notice-log

### DIFF
--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -168,6 +168,7 @@ module.exports = {
       //this is the cli client, just ignore.
       if(rpc.id === sbot.id) return
 
+      var startTS = Date.now()
       sbot.emit('log:info', ['replicate', rpc.id, 'start'])
       sbot.emit('replicate:start', rpc)
       replicate(sbot, config, rpc, function (err, final, initial) {
@@ -180,7 +181,7 @@ module.exports = {
           for (var author in final)
             progress[author] = final[author] - (initial[author] || 0)
 
-          var progressSummary = summarizeProgress(progress)
+          var progressSummary = summarizeProgress(progress, Date.now() - startTS)
           if (progressSummary)
             sbot.emit('log:notice', ['replicate', rpc.id, 'success', progressSummary])
           sbot.emit('replicate:finish', final)
@@ -196,7 +197,7 @@ module.exports = {
   }
 }
 
-function summarizeProgress (progress) {
+function summarizeProgress (progress, timeDelta) {
   // count the number of feeds updated, and the number of new messages
   var updatedFeeds = 0, newMessages = 0
   for (var author in progress) {
@@ -208,7 +209,13 @@ function summarizeProgress (progress) {
   // no message if no updates
   if (updatedFeeds === 0)
     return false
-  return 'Feeds updated: '+updatedFeeds+', New messages: '+newMessages
+
+  // create a nicely-formatted time
+  var timeDeltaMM = Math.floor(timeDelta / (1e3*60))
+  var timeDeltaSS = Math.floor((timeDelta % (1e3*60)) / 1e3)
+  var timeDeltaNice = ''+timeDeltaMM+'m'+timeDeltaSS+'s'
+
+  return 'Feeds updated: '+updatedFeeds+', New messages: '+newMessages+', in '+timeDeltaNice
 }
 
 


### PR DESCRIPTION
Adds some time information so we can get an idea of the throughput:

```
note @pzI REPL @uRECWB4KIeKoNMis2UYWyB2aQPvWmS3OePQvBj2zClg=.ed25519 success
  "Feeds updated: 20, New messages: 28, in 0m31s"
```