### PR TITLE
Demo PR - Sandboxed plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var fs         = require('fs')
 var cmdAliases = require('./lib/cli-cmd-aliases')
 var valid      = require('./lib/validators')
 var apidocs    = require('./lib/apidocs.js')
+var plugins    = require('./lib/plugins')
 
 function toBuffer(base64) {
   return new Buffer(base64.substring(0, base64.indexOf('.')), 'base64')
@@ -81,6 +82,10 @@ var SSB = {
 
     if(!opts.path)
       throw new Error('opts.path *must* be provided, or use opts.temp=sname to create a test instance')
+
+    // DEBUG load test plugins
+    var p = plugins.spawn(path.join(__dirname, 'plugins/hello-world.js'), { ping: 'async' })
+    p.ipcApi.ping(function (err, ret) { console.log('ping -', err, ret) })
 
     var ssb = create(path.join(opts.path, 'db'), null, opts.keys)
     var feed = ssb.createFeed(opts.keys)

--- a/lib/ipc-api-stream.js
+++ b/lib/ipc-api-stream.js
@@ -1,0 +1,122 @@
+'use strict'
+// [I]nter[P]rocess [C]ommunication API Stream
+
+// TODO put this into `pull-ipc` -prf
+
+var pull = require('pull-stream')
+var once = require('once')
+
+// how to use
+
+// from parent process:
+// var stream = ipcApiStream(childProcess, function() { console.log('ipc stream is closed') })
+
+// from child process:
+// var stream = ipcApiStream(process, function() { console.log('ipc stream is closed') })
+
+// then:
+// var api = muxrpc(theirApiManifest, myApiManifest)(myApiDefinition)
+// pull(stream, api.createStream(), stream)
+
+module.exports = function (processObj, cb) {
+  var listener
+  return createChannelStream(
+    // send function. this is how does the channel stream sends a message
+    (function send (msg) {
+      processObj.send(msg)
+    }),
+    // listen function. this registers a callback to handle incoming messages
+    (function listen (cb) {
+      processObj.on('message', (listener = function (msg) {
+        cb(msg)
+      }))
+    }),
+    // cleanup function. this is called on channel-close
+    (function cleanup (err, v) {
+      processObj.removeListener('message', listener)
+      listener = null
+      if (cb)
+        cb(err, v)
+    })
+  )
+}
+
+// TODO is the serializer needed, or does node's IPC interface handle it?
+// function serialize (stream) {
+//   return Serializer(stream, JSON, {split: '\n\n'})
+// }
+
+function createChannelStream (send, listen, cleanup) {
+  var buffer = [], ended = false, waiting
+
+  var done = once(function (err, v) {
+    ended = err || true
+    cleanup(err, v)
+
+    // deallocate
+    waiting = null
+  })
+
+  // incoming msg handler
+  listen(function onincoming (msg) {
+    // console.log('in', msg)
+
+    // parse if needed
+    try {
+      if (typeof msg == 'string')
+        msg = JSON.parse(msg)
+    } catch (e) {
+      return
+    }
+
+    if (msg.bvalue) {
+      // convert buffers to back to binary
+      msg.value = new Buffer(msg.bvalue, 'base64')
+      delete msg.bvalue
+    }
+
+    // send to pull-stream if it's waiting for data
+    // otherwise, buffer the data
+    if (waiting) {
+      var cb = waiting
+      waiting = null
+      cb(ended, msg)
+    }
+    else if (!ended)
+      buffer.push(msg)
+  })
+
+  // outgoing msg handler
+  function onoutgoing (msg) { 
+    // console.log('out', msg)
+
+    if (msg.value && Buffer.isBuffer(msg.value)) {
+      // convert buffers to base64
+      msg.bvalue = msg.value.toString('base64')
+      delete msg.value
+    }
+    send(msg)
+  }
+
+  // return source/sink
+  return {
+    source: function (abort, cb) {
+      if (abort) {
+        cb(abort)
+        done(abort !== true ? abort : null)
+      }
+      else if (buffer.length) cb(null, buffer.shift())
+      else if (ended) cb(ended)
+      else waiting = cb
+    },
+    sink  : function (read) {
+      pull.drain(function (data) {
+        if (ended) return false
+        onoutgoing(data)
+      }, function (err) {
+        if (done)
+          done(err)
+      })(read)
+    }
+  }
+}

--- a/lib/plugin-sandbox.js
+++ b/lib/plugin-sandbox.js
@@ -1,0 +1,42 @@
+var vm = require('vm')
+var fs = require('fs')
+var pathlib = require('path')
+var muxrpc = require('muxrpc')
+var pull = require('pull-stream')
+var ipcApiStream = require('./ipc-api-stream')
+
+const PARENT_IPC_MANIFEST = { /* no methods yet */ }
+var child_ipc_manifest = {}
+
+// read child manifest from env vars
+try { child_ipc_manifest = JSON.parse(process.env.script_manifest) }
+catch (e) {}
+
+// read script
+var path = process.env.script_path
+var name = pathlib.basename(path)
+var script = fs.readFileSync(path, 'utf-8')
+if (!script || typeof script !== 'string')
+  throw "Failed to read script"
+
+// create module object for the plugin to export with
+var vmModule = { exports: {} }
+
+// setup RPC channel with parent process
+var ipcStream = ipcApiStream(process, function(err) { console.error(err); throw 'parent-process ipc stream was killed' })
+var ipcApi = muxrpc(PARENT_IPC_MANIFEST, child_ipc_manifest, msg => msg)(vmModule.exports) // note, we route the requests to the VM's module.exports
+pull(ipcStream, ipcApi.createStream(), ipcStream)
+
+// launch VM
+var context = vm.createContext({
+  module: vmModule,
+  exports: vmModule.exports,
+  console: {
+    log: console.log.bind(console, name, '-'),
+    info: console.info.bind(console, name, '-'),
+    warn: console.warn.bind(console, name, '-'),
+    error: console.error.bind(console, name, '-')
+  },
+  sbot: ipcApi
+})
+var vmInstance = vm.runInContext(script, context)

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,0 +1,74 @@
+'use strict'
+
+var childProcess = require('child_process')
+var pathlib = require('path')
+var url = require('url')
+var ipcApiStream = require('./ipc-api-stream')
+var muxrpc = require('muxrpc')
+var pull = require('pull-stream')
+var zerr = require('zerr')
+
+const NODE_PATH = process.execPath
+const PLUGIN_LOADER = pathlib.join(__dirname, 'plugin-sandbox.js')
+
+const IPC_MANIFEST = {}
+//   registerService: 'sync',
+//   queryServices: 'sync'
+// }
+const IPC_API = {}// registerService, queryServices }
+// const NotYetImplementedError = zerr('NotYetImplemented')
+
+var activePlugins = []
+var pathRegistry = {}
+
+module.exports.spawn = function (path, manifest) {
+
+  // spawn the process
+  var childProcessInstance = childProcess.spawn(NODE_PATH, [PLUGIN_LOADER], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    cwd: pathlib.dirname(path),
+    env: {
+      script_path: path,
+      script_manifest: JSON.stringify(manifest||{})
+    }
+  })
+  console.log(path, '- started.')
+
+  // setup ipc api
+  var ipcStream = ipcApiStream(childProcessInstance, function() { console.log(path, '- ipc stream closed.') })
+  var ipcApi = muxrpc(manifest || {}, IPC_MANIFEST, msg => msg)(IPC_API)
+
+  // add to the registry
+  var plugin = {
+    path: path,
+    process: childProcessInstance,
+    ipcStream: ipcStream,
+    ipcApi: ipcApi,
+    state: { isAlive: true, code: null, signal: null }
+  }
+  pathRegistry[path] = plugin
+  activePlugins.push(plugin)
+
+  // start the api stream
+  ipcApi.id = path
+  pull(ipcStream, ipcApi.createStream(), ipcStream)
+
+  // watch for process death
+  childProcessInstance.on('close', function (code, signal) {
+    console.log(path, '- stopped. Code:', code, 'Signal:', signal)
+
+    // record new state
+    plugin.state.isAlive = false
+    plugin.state.code = code
+    plugin.state.signal = signal
+
+    // remove from registries
+    delete pathRegistry[path]
+    activePlugins.splice(activePlugins.indexOf(plugin), 1)
+  })
+  return plugin
+}
+
+module.exports.killAll = function (signal) {
+  activePlugins.forEach(plugin => plugin.process.kill(signal || 'SIGHUP'))
+}

--- a/plugins/hello-world.js
+++ b/plugins/hello-world.js
@@ -1,0 +1,5 @@
+console.log('hello, world!')
+console.log(this)
+exports.ping = function (cb) {
+  cb(null, 'pong')
+}


### PR DESCRIPTION
Yesterday, on the team call, we talked about CouchDB's architecture, which runs user-scripts to generate views and define queries. Using Couch's file-attachments system, they have the entire Couch Apps platform.

That got me thinking about how we might do the same in Scuttlebot. Perhaps it would be an avenue for the Ultra apps?

This PR demonstrates a sandboxed plugin which could support that. (I extracted it from EAppEnv.) It adds a `plugins.spawn(path, manifest)` function, which takes the JS file to execute, and the JS file's muxrpc manifest. The JS runs in a sandboxed VM in a child process, and uses STDIO for muxrpc traffic with sbot.

This plugin sandbox should support all of the existing plugins; that is, I think we could port them to run this way. See the changes to `index.js` for a usage example within sbot. See `plugins/hello-world.js` for a plugin definition. If you checkout this `sandboxed-plugins` branch, run `./bin.js server` to see the demo output.

(This PR has demo code - it's not merge-ready.)