### PR TITLE
disable all quotas by setting party mode

### DIFF
--- a/plugins/blobs/replication.js
+++ b/plugins/blobs/replication.js
@@ -73,6 +73,7 @@ module.exports = function (sbot, opts, notify, quota) {
   }
 
   function limitFor(id) {
+    if(opts.party) return -1
     var h = hops(id)
     if(hops === -1) return conf.minLimit
     return conf.limit[h] || conf.minLimit

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -69,6 +69,7 @@ function replicate(sbot, config, rpc, cb) {
     })
 
     rpc.on('call:createHistoryStream', function (opts) {
+      //console.log(opts)
       to_send[opts.id] = (opts.sequence || opts.seq) - 1
       debounce.set()
     })
@@ -122,7 +123,7 @@ function replicate(sbot, config, rpc, cb) {
         to_recv[upto.id] = upto.sequence
         initial[upto.id] = replicated[upto.id] = upto.sequence
 
-        var limit = calcLimit(upto)
+        var limit = config.party ? null : calcLimit(upto)
 
         sources.add(
           pull(
@@ -223,6 +224,7 @@ function summarizeProgress (progress) {
     return false
   return 'Feeds updated: '+updatedFeeds+', New messages: '+newMessages
 }
+
 
 
 


### PR DESCRIPTION
quotas wasn't working well, and, I suspect that calculating the path to the sharer in the blobs quotas system might be what is causing the spinning cpu.

``` 
ssb_party=1 ./bin.js server
```
or edit config. otherwise this is backwards compatible, so we can merge this into patchwork and let people who where having problems test it an see if it improves.