### PR TITLE
set remote key via host, to be client to another sbot

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -59,7 +59,7 @@ try {
 // connect
 require('ssb-client')(keys, {manifest: manifest,
   port: config.port, host: config.host||'localhost',
-  key: keys.id
+  key: config.key || keys.id
 }, function (err, rpc) {
   if(err) {
     if (/could not connect/.test(err.message)) {


### PR DESCRIPTION
Once upon a time this was possible but it got trampled somewhere.
This enables you to set a `master` configuration on your pub, and command your pubserver to accept commands from your local client, which has better latency than sshing onto the server and then running local commands.