### PR TITLE
if an invite code is surrounded in quotes, automatically remove them

### DIFF
--- a/plugins/invite.js
+++ b/plugins/invite.js
@@ -117,6 +117,10 @@ module.exports = {
         })
       }, 'object'),
       accept: valid.async(function (invite, cb) {
+        // remove surrounding quotes, if found
+        if (invite.charAt(0) === '"' && invite.charAt(invite.length - 1) === '"')
+          invite = invite.slice(1, -1)
+
         var parts = invite.split('~')
         var addr = toAddress(parts[0])
 


### PR DESCRIPTION
Invite codes are outputted with quotes around them, so sometimes they get shared that way. I had somebody get tripped up by this, so automatically stripping the quotes is probably a good idea.