### PR TITLE
Validation now checks for a CB on async methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ var SSB = {
 
       usage                    : valid.sync(usage, 'string?|boolean?'),
 
-      publish                  : valid.async(feed.add, 'string|msgContent'),
-      add                      : valid.async(ssb.add, 'msg'),
+      publish                  : valid.async(feed.add, { cbOptional: true }, 'string|msgContent'),
+      add                      : valid.async(ssb.add, { cbOptional: true }, 'msg'),
       get                      : valid.async(ssb.get, 'msgId'),
 
       pre                      : ssb.pre,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "multiblob": "^1.8.1",
     "multicb": "^1.0.0",
     "muxrpc": "^6.1.1",
-    "muxrpc-validation": "^2.0.0",
+    "muxrpc-validation": "^3.0.0",
     "muxrpcli": "^1.0.0",
     "mynosql-query": "~1.0.0",
     "nomnom": "1.8.0",


### PR DESCRIPTION
Updates to use https://github.com/pfraze/muxrpc-validation/pull/1

This makes it so an async call that's missing its callback will throw an error (unless an opt is set to allow no cb).

muxrpc-validation's previous behavior was to create a callback for you, which throws if an error comes back. That's an ok choice, but I think it's better to force the caller to provide a CB.
