### PR TITLE
Expose log command in logging plugin

### DIFF
--- a/lib/apidocs.js
+++ b/lib/apidocs.js
@@ -8,5 +8,6 @@ module.exports = {
   gossip: fs.readFileSync(path.join(__dirname, '../plugins/gossip.md'), 'utf-8'),
   invite: fs.readFileSync(path.join(__dirname, '../plugins/invite.md'), 'utf-8'),
   'private': fs.readFileSync(path.join(__dirname, '../plugins/private.md'), 'utf-8'),
+  logging: fs.readFileSync(path.join(__dirname, '../plugins/logging.md'), 'utf-8'),
   replicate: fs.readFileSync(path.join(__dirname, '../plugins/replicate.md'), 'utf-8')
 }

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -19,7 +19,7 @@ function indent (o) {
 }
 
 function isString(s) {
-  return 'string' === s
+  return 'string' === typeof s
 }
 
 function formatter(id, level) {

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -51,7 +51,16 @@ function formatter(id, level) {
   }
 }
 
-module.exports = function logging (server, conf) {
+exports.name = 'logging'
+exports.init = module.exports
+exports.manifest = {
+  log: 'sync'
+}
+exports.permissions = {
+  master: {allow: ['log']},
+}
+
+exports.init = function (server, conf) {
   var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level) || DEFAULT_LEVEL
   if (level === -1) {
     console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)
@@ -69,6 +78,11 @@ module.exports = function logging (server, conf) {
     server.on('log:warning', formatter(id, color.yellow('warn')))
   if (level >= LOG_LEVELS.indexOf('error'))
     server.on('log:error',   formatter(id, color.red('err!')))
-}
 
-module.exports.init = module.exports
+  return {
+    log: function (levelName, plug, id, verb) {
+      server.emit('log:' + levelName, [].slice.call(arguments, 1))
+      return (LOG_LEVELS.indexOf(levelName) !== -1)
+    }
+  }
+}


### PR DESCRIPTION
This makes the log function from the logging plugin be usable as a method/command. This makes it possible for ssb apps connecting to scuttlebot using ssb-client to log messages to the same output to which sbot's log messages go.

Also I added an API doc for the log function and updated an isString function to be more accepting of strings
