### PR TITLE
set configuration via cli, via arguments following --

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "level-memview": "~0.0.0",
     "map-merge": "~1.1.0",
     "mdmanifest": "^1.0.4",
-    "minimist": "~1.1.0",
+    "minimist": "^1.1.3",
     "mkdirp": "~0.5.0",
     "multiblob": "^1.8.1",
     "multicb": "^1.0.0",


### PR DESCRIPTION
As proposed in `%pgYqhasRHhBsbLHpCh/CJetYJiTUdT1ILdIrxPelMWI=.sha256`,
this pr adds support to sbot for setting configuration via the command line interface.