### PR TITLE
Fix 11f01217 to make 0f96771a work again

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -17,7 +17,7 @@ var cmdAliases   = require('./lib/cli-cmd-aliases')
 var argv = process.argv.slice(2)
 var i = argv.indexOf('--')
 var conf = argv.slice(i+1)
-argv = ~i ? argv.slice(0) : argv
+argv = ~i ? argv.slice(0, i) : argv
 
 var config = require('ssb-config/inject')(process.env.ssb_appname, minimist(conf))
 


### PR DESCRIPTION
Commit 11f01217 (oops, fix so you can actually start the server when not
using --, 2016-05-15) broke the change from commit 0f96771a (separate
argv by -- and use later part for configuration., 2016-05-14).

Fix this by adding back the i part of the argv.slice.

Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>