### PR TITLE
plugins/friends: only allow feeds as friends (not messages)

### DIFF
--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -48,7 +48,7 @@ exports.init = function (sbot, config) {
 
     var c = msg.value.content
     if (c.type == 'contact') {
-      mlib.asLinks(c.contact).forEach(function (link) {
+      mlib.asLinks(c.contact, 'feed').forEach(function (link) {
         if ('following' in c) {
           if (c.following)
             graphs.follow.edge(msg.value.author, link.link, true)


### PR DESCRIPTION
As posted in the #scuttlebot channel on patchwork:

> I accidently followed a message (instead of a feed) by copy/pasting the wrong id into sbot publish. It completely broke replication for my local instance. No errors, just replication never finishes. Didn't seem to affect the outside world, but not 100% sure about that yet.

>Even publishing an unfollow didn't fix it. The only way for me to avoid scrapping this feed is to manually filter out non-feed ids from the friends list. Maybe this should be in scuttlebot by default?

@dominictarr This is probably a bug, really scuttlebot should not be able to treat non-feeds as friends. 

**This PR enforces that all `follows` specified by `contact` posts are `feeds`, and will ignore other types of messages.**