### PR TITLE
pass caps from config to ssb-client

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -78,6 +78,7 @@ if (argv[0] == 'server') {
     manifest: manifest,
     port: config.port,
     host: config.host||'localhost',
+    caps: config.caps,
     key: config.key || keys.id
   }, function (err, rpc) {
     if(err) {


### PR DESCRIPTION
before, the ` "caps": {"shs": "...." } ` in `.ssb/config` wouldn't get passed to `sbot` client calls, like `whoami`.


(re %sRD2wfvldRwi95yqTTN5SRnmoG0c1ktcXFSUF8lQlh8=.sha256)