### PR TITLE
[flume] fix bin export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "tape": "~4.0.0"
   },
   "bin": {
-    "sbot": "./sbot.js"
+    "sbot": "./bin.js",
+    "scuttlebot": "./bin.js"
   },
   "scripts": {
     "prepublish": "npm ls && npm test && noderify bin.js > sbot.js",


### PR DESCRIPTION
also export `scuttlebot` command, since `sbot` can be confusing if you expect the convention where the exported command matches the name of the package.