### PR TITLE
automatically remove old local peers from peer table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 sudo: false
 node_js:
-  - 'iojs-v2.5.0'
+  - '6.9.5'

--- a/plugins/gossip.md
+++ b/plugins/gossip.md
@@ -37,6 +37,20 @@ add({ host:, port:, key: }, cb)
  - `port` (port number)
  - `key` (feedid)
 
+## remove: sync
+
+Remove an address from the peer table.
+
+```bash
+remove {addr}
+remove --host {string} --port {number} --key {feedid}
+```
+
+```js
+remove(addr)
+remove({ host:, port:, key: })
+```
+
 ## ping: duplex
 
 used internally by the gossip plugin to measure latency and clock skew

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -151,6 +151,13 @@ module.exports = {
 
         return f
       }, 'string|object', 'string?'),
+      remove: function (addr) {
+        var peer = gossip.get(addr)
+        var index = peers.indexOf(peer)
+        if (~index) {
+          peers.splice(index, 1)
+        }
+      },
       ping: function (opts) {
         var timeout = config.timers && config.timers.ping || 5*60e3
         //between 10 seconds and 30 minutes, default 5 min
@@ -248,4 +255,3 @@ module.exports = {
     return gossip
   }
 }
-

--- a/plugins/local.js
+++ b/plugins/local.js
@@ -14,16 +14,33 @@ module.exports = {
   init: function (sbot, config) {
 
     var local = broadcast(config.port)
+    var addrs = {}
+    var lastSeen = {}
 
+    // cleanup old local peers
+    setInterval(function () {
+      Object.keys(lastSeen).forEach((key) => {
+        if (Date.now() - lastSeen[key] > 10e3) {
+          sbot.gossip.remove(addrs[key])
+          delete lastSeen[key]
+        }
+      })
+    }, 5e3)
+
+    // discover new local peers
     local.on('data', function (buf) {
-      if(buf.loopback) return
+      if (buf.loopback) return
       var data = buf.toString()
-      if(ref.parseAddress(data))
+      var peer = ref.parseAddress(data)
+      if (peer && peer.key !== sbot.id) {
+        addrs[peer.key] = peer
+        lastSeen[peer.key] = Date.now()
         sbot.gossip.add(data, 'local')
+      }
     })
 
+    // broadcast self
     setInterval(function () {
-      // broadcast self
       // TODO: sign beacons, so that receipient can be confidant
       // that is really your id.
       // (which means they can update their peer table)
@@ -33,6 +50,3 @@ module.exports = {
     }, 1000)
   }
 }
-
-
-


### PR DESCRIPTION
Currently if sbot discovers a local peer, it will keep it in the peer table forever, even if that local peer goes offline or you change networks. This has a few problems (including sbot trying to connect to missing peers), but also makes it hard to easily access a list of local peers. 

**This PR adds an automatic cleanup to `local` that will remove peers from the `gossip` table that haven't broadcasted in over 10 seconds.**

With this PR in place, `patchwork-next` will no longer have to override the gossip and local modules and will be able to work properly on top of a standard sbot server.

<img width="350" alt="screen shot 2017-02-15 at 4 32 21 pm" src="https://cloud.githubusercontent.com/assets/66834/22959573/5ef1ed1c-f39c-11e6-8505-f5bf314bc695.png">

cc @ahdinosaur @dominictarr @mixmix 