### PR TITLE
Improve replication error handling

### DIFF
--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -176,10 +176,12 @@ module.exports = {
       //don't track clients that connect, but arn't considered peers.
       //maybe we should though?
       if(!peer) {
-        console.log('Connected', rpc.id)
-        rpc.on('closed', function () {
-          console.log('Disconnected', rpc.id)
-        })
+        if(rpc.id !== server.id) {
+          console.log('Connected', rpc.id)
+          rpc.on('closed', function () {
+            console.log('Disconnected', rpc.id)
+          })
+        }
         return
       }
 

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -112,7 +112,7 @@ module.exports = {
         peer.state = 'disconnecting'
         peer.stateChange = Date.now()
         if(!peer || !peer.disconnect) cb && cb()
-        else peer.disconnect(null, function (err) {
+        else peer.disconnect(true, function (err) {
           peer.stateChange = Date.now()
         })
 

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -175,7 +175,14 @@ module.exports = {
       var peer = getPeer(rpc.id)
       //don't track clients that connect, but arn't considered peers.
       //maybe we should though?
-      if(!peer) return
+      if(!peer) {
+        console.log('Connected', rpc.id)
+        rpc.on('closed', function () {
+          console.log('Disconnected', rpc.id)
+        })
+        return
+      }
+
       console.log('Connected', stringify(peer))
       //means that we have created this connection, not received it.
       peer.client = !!isClient

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -22,9 +22,12 @@ function last (a) { return a[a.length - 1] }
 var streamErrors = {
   'unexpected end of parent stream': true, // stream closed okay
   'unexpected hangup': true, // stream closed probably okay
-  'read EHOSTUNREACH': true, // unable to connect
-  'read ECONNRESET': true, // stream broke during read
-  'write EPIPE': true, // stream broke during write
+  'read EHOSTUNREACH': true,
+  'read ECONNRESET': true,
+  'read ENETDOWN': true,
+  'read ETIMEDOUT': true,
+  'write ECONNRESET': true,
+  'write EPIPE': true,
   'stream is closed': true, // rpc method called after stream ended
 }
 


### PR DESCRIPTION
as discussed in [%SMqHQTSeyR8Zq0KcSe2z0HbvjW1CqKIlJ1leuVVL4G0=.sha256](https://viewer.scuttlebot.io/%25SMqHQTSeyR8Zq0KcSe2z0HbvjW1CqKIlJ1leuVVL4G0%3D.sha256):

- log a stream error only if it is not one of the expected benign errors, and then only log it once instead of logging it for each substream.

also, pre-emptively close legacy erroring substreams, to save bandwidth (analysis in [%368B7blWHcWTEzqGO4DDipDBCLwvRlKxwVxTOFtV9kY=.sha256](https://viewer.scuttlebot.io/%25368B7blWHcWTEzqGO4DDipDBCLwvRlKxwVxTOFtV9kY%3D.sha256)

and also, show Connected/Disconnect on the log for peers that are not in the peer table (e.g. incoming non-pub connections)