### PR TITLE
fix realtime replication push

### DIFF
--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -99,7 +99,7 @@ module.exports = {
           pushable.splice(i, 1)
         })
         pushable.push(p)
-        pushable.sequence = upto.sequence
+        pushable.sequence = seq
         return p
       }
       return fn.call(this, upto)


### PR DESCRIPTION
Finally tracked this thing down! 🎉 

There is a typo in `plugins/replicate.js` that uses `opts.sequence` instead of  `opts.sequence || opts.seq` causing realtime push to break.

This is most commonly noticeable when connected to someone on the local network and you don't see their posts until after they restart, but I suspect this has been breaking persistent gossip for ages!

cc @dominictarr @mixmix @ahdinosaur @clehner 