### PR TITLE
port patchwork style progress to scuttlebot

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "pull-inactivity": "~2.1.1",
     "pull-level": "^2.0.2",
     "pull-many": "~1.0.6",
+    "pull-next": "0.0.2",
     "pull-notify": "0.1.1",
     "pull-paramap": "~1.2.1",
     "pull-ping": "^2.0.2",
@@ -61,7 +62,6 @@
   },
   "devDependencies": {
     "cat-names": "~1.0.2",
-    "deep-equal": "~1.0.0",
     "dog-names": "~1.0.2",
     "level-sublevel": "~6.3.15",
     "level-test": "^2.0.1",

--- a/plugins/friends.js
+++ b/plugins/friends.js
@@ -124,6 +124,12 @@ exports.init = function (sbot, config) {
         return ps.push(meta ? {id: to, hops: hops} : to)
       }
 
+      if (live) {
+        awaitSync(function () {
+          ps.push({sync: true})
+        })
+      }
+
       //by default, also emit your own key.
       if(opts.self !== false)
         push(start, 0)

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -53,9 +53,11 @@ module.exports = {
       // only list loaded feeds once we know about all of them!
       var feeds = loadedFriends ? Object.keys(toSend).length : null
       var legacyProgress = 0
+      var legacyTotal = 0
 
       var pendingFeeds = new Set()
       var pendingPeers = {}
+      var legacyToRecv = {}
 
       Object.keys(pendingFeedsForPeer).forEach(function (peerId) {
         if (pendingFeedsForPeer[peerId]) {
@@ -76,13 +78,28 @@ module.exports = {
         legacyProgress += toSend[k]
       }
 
+      for (var id in peerHas) {
+        for (var k in peerHas[id]) {
+          legacyToRecv[k] = Math.max(peerHas[id][k], legacyToRecv[k] || 0)
+        }
+      }
+
+      for (var k in legacyToRecv) {
+        if (toSend[k] !== null) {
+          legacyTotal += legacyToRecv[k]
+        }
+      }
+
       var progress = {
         id: sbot.id,
         rate, // rate of messages written to sbot
-        progress: legacyProgress, // LEGACY: needed for test/random.js to pass
         feeds, // total number of feeds we want to replicate
         pendingPeers, // number of pending feeds per peer
-        incompleteFeeds: pendingFeeds.size // number of feeds with pending messages to download
+        incompleteFeeds: pendingFeeds.size, // number of feeds with pending messages to download
+
+        // LEGACY: Preserving old api. Needed for test/random.js to pass
+        progress: legacyProgress,
+        total: legacyTotal
       }
 
       if (!deepEqual(progress, lastProgress)) {

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -52,6 +52,7 @@ module.exports = {
     debounce(function () {
       // only list loaded feeds once we know about all of them!
       var feeds = loadedFriends ? Object.keys(toSend).length : null
+      var legacyProgress = 0
 
       var pendingFeeds = new Set()
       var pendingPeers = {}
@@ -71,9 +72,14 @@ module.exports = {
         }
       })
 
+      for (var k in toSend) {
+        legacyProgress += toSend[k]
+      }
+
       var progress = {
         id: sbot.id,
         rate, // rate of messages written to sbot
+        progress: legacyProgress, // LEGACY: needed for test/random.js to pass
         feeds, // total number of feeds we want to replicate
         pendingPeers, // number of pending feeds per peer
         incompleteFeeds: pendingFeeds.size // number of feeds with pending messages to download

--- a/test/random.js
+++ b/test/random.js
@@ -233,9 +233,11 @@ tape('replicate social network for animals', function (t) {
     })
   })
 
+  var drain
+
   pull(
     animalFriends.replicate.changes(),
-    pull.drain(function (prog) {
+    drain = pull.drain(function (prog) {
       prog.id = 'animal friends'
       var target = F+N+3
       console.log(prog, target)
@@ -246,6 +248,7 @@ tape('replicate social network for animals', function (t) {
         var time = (Date.now() - start) / 1000
         console.log('replicated', target, 'messages in', time, 'at rate',target/time)
         animalFriends.close(true)
+        drain.abort()
         t.end()
       }
     })


### PR DESCRIPTION
As per ssbc/patchwork#447, this PR removes patchwork's need to be running a forked sbot version.

## Compatibility

I was going to remove the old `progress` but it turns out some tests need it to pass, so I left it in. I have also left the old `total` value in. This is kind of broken because `total - progress` usually never quite makes it to `0`, but it is better than it used to be (there was an off by 1 error in the old code).

The old `feeds` was broken since adding persistent gossip. From the code, it looked like it was supposed to count the number of feeds currently syncing, but since they never stopped, it didn't decrement until the peer disconnected. Seemed a little silly to me. **So I've changed it to now be the total number of feeds we know about**.

## New stuff

### `incompleteFeeds`

It gives us the total number of feeds that connected peers _claim_ they have more recent than us. This avoids the problem of the old system that sometimes never made it to 0. If we disconnect from a peer and didn't reach the _claimed_ max sequence, we stop counting it as a pending feed. 

Used for the **downloading messages** progress state in patchwork. 

### `pendingPeers`

It gives us the total number of pending feeds for each peer still syncing.

```
{ '@uRECWB4KIeKoNMis2UYWyB2aQPvWmS3OePQvBj2zClg=.ed25519': 1495,
   '@7nTbqZVRYRo7FokY8BBYGpXvvveRPb4u+G1vunRmNn4=.ed25519': 1425,
   '@J2VKbbf69rK38vXIRLOCwaZdEm+0vzv/LMeaxmJks3k=.ed25519': 862 
}
```

Used for the sync status progress spinners under "Connected Pubs" in the patchwork sidebar.

### add `sync` event on `createFriendStream`

Otherwise we don't know (when running with `live: true`) that we have finished loading the friends list. Used for only broadcasting `feeds` once we actually know how many feeds there are.

There is possibly room for some discussion here, but, eh. Works for patchwork.