### PR TITLE
send sync over history stream

### DIFF
--- a/plugins/block.js
+++ b/plugins/block.js
@@ -48,6 +48,7 @@ exports.init = function (sbot) {
         //the recipient.
         pull.take(function (msg) {
           //handle when createHistoryStream is called with keys: true
+          if(msg.sync) return true
           if(!msg.content && msg.value.content)
             msg = msg.value
           if(msg.content.type !== 'contact') return true

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -320,9 +320,12 @@ function createHistoryStreamWithSync (rpc, upto, onSync) {
       keys: false
     }),
     pull.filter(msg => {
-      if (msg.sync) return false
-      onSync && onSync()
-      return true
+      if (msg.sync) {
+        onSync && onSync()
+        return false
+      } else {
+        return true
+      }
     })
   )
 }

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -311,23 +311,18 @@ function createHistoryStreamWithSync (rpc, upto, onSync) {
   // HACK: createHistoryStream does not emit sync event, so we don't
   // know when it switches to live. Do it manually!
   var last = (upto.sequence || upto.seq || 0)
-  var state = null
   return pull(
     rpc.createHistoryStream({
       id: upto.id,
       seq: last + 1,
-      sync: false,
+      sync: false, // actual means true, see https://github.com/ssbc/scuttlebot/pull/383
       live: true,
       keys: false
     }),
     pull.filter(msg => {
-      if(msg.sync) return false
-      last = Math.max(last, msg.sequence)
+      if (msg.sync) return false
+      onSync && onSync()
       return true
     })
   )
 }
-
-
-
-


### PR DESCRIPTION
this avoids making two requests to createHistoryStream (which doubles bandwidth used by the handshake, which for 1k feeds is a lot!)

The problem with this method, is that it depends on the bug in createHistoryStream https://github.com/ssbc/secure-scuttlebutt/issues/163

but the problem with this is it depends on what the remote sends us back, and it's not known if they have this bug or not. we could fix it but then we couldn't know for sure whether it's rolled out to every peer.

This is used for progress bars though, and the previous way was to compare with the sequence they have requested for this feed - are there any problems with that?

thoughts @mmckegg @clehner ?