### PR TITLE
fix progress stalling when pubs disconnect before completion

### DIFF
--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -288,7 +288,10 @@ module.exports = {
                 }
               }
 
-              pendingFeedsForPeer[rpc.id].delete(upto.id)
+              if (pendingFeedsForPeer[rpc.id]) {
+                pendingFeedsForPeer[rpc.id].delete(upto.id)
+              }
+
               debounce.set()
             })
           )

--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -60,7 +60,7 @@ module.exports = {
       var legacyToRecv = {}
 
       Object.keys(pendingFeedsForPeer).forEach(function (peerId) {
-        if (pendingFeedsForPeer[peerId]) {
+        if (pendingFeedsForPeer[peerId] && pendingFeedsForPeer[peerId].size) {
           Object.keys(toSend).forEach(function (feedId) {
             if (peerHas[peerId] && peerHas[peerId][feedId]) {
               if (peerHas[peerId][feedId] > toSend[feedId]) {
@@ -68,9 +68,7 @@ module.exports = {
               }
             }
           })
-          if (pendingFeedsForPeer[peerId].size) {
-            pendingPeers[peerId] = pendingFeedsForPeer[peerId].size
-          }
+          pendingPeers[peerId] = pendingFeedsForPeer[peerId].size
         }
       })
 
@@ -251,6 +249,8 @@ module.exports = {
       sbot.emit('replicate:start', rpc)
       rpc.on('closed', function () {
         sbot.emit('replicate:finish', toSend)
+        delete pendingFeedsForPeer[rpc.id]
+        debounce.set()
       })
       var errorsSeen = {}
       pull(


### PR DESCRIPTION
Just noticed that sometimes (particularly right now with the high load on pubs) the "downloading messages" progress stalls and never completes. The only way to make the progress bar go away is to restart.

Turns out it is a display only issue. This PR correctly handles cleanup when a pub disconnects before sync completes.