### PR TITLE
replicate: reduce bandwidth by replacing double stream with peerHas check

### DIFF
--- a/plugins/replicate.js
+++ b/plugins/replicate.js
@@ -336,7 +336,6 @@ function detectSync (peerId, upto, toSend, peerHas, onSync) {
     } else {
       // if we get here, the peer hasn't yet asked for this feed, or is not responding
       // we can assume it doesn't have the feed, so lets call sync
-      console.log('timeout')
       broadcastSync()
     }
   }, 500)


### PR DESCRIPTION
Continuing from #383. Here's an alternative strategy that uses what we know about the peer already to decide when to mark as sync. It also falls back to a timeout after 3 seconds of no message received. 

Does this look okay? @dominictarr @clehner @ahdinosaur 