### PR TITLE
remove (unintended?) console.log from gossip

### DIFF
--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -81,7 +81,6 @@ module.exports = {
 
         if(!addr.key) return cb(new Error('address must have ed25519 key'))
         // add peer to the table, incase it isn't already.
-        console.log('connect', addr)
         gossip.add(addr, 'manual')
         var p = gossip.get(addr)
         if(!p) return cb()


### PR DESCRIPTION
https://github.com/ssbc/scuttlebot/commit/ac51d55eb952fb66353ffa811b94522fee651e1a#commitcomment-21850365

Probably not supposed to be here, right?