### PR TITLE
Use ssb-ref 2.7.1 which works for IPv4 and IPv6

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ssb-config": "^2.0.0",
     "ssb-keys": "^7.0.0",
     "ssb-msgs": "~5.2.0",
-    "ssb-ref": "^2.6.2",
+    "ssb-ref": "^2.7.1",
     "ssb-ws": "^1.0.1",
     "statistics": "^3.0.0",
     "stream-to-pull-stream": "^1.6.10",


### PR DESCRIPTION
Current scuttlebot depends on ssb-ref `^2.6.2`, which for some people due to semver might be installed as 2.6.**3**. Version 2.6.3 is pooped because it [broke support for IPv4](https://github.com/ssbc/ssb-ref/issues/10). I suspect some people might be getting problems with this.