### PR TITLE
Improve robustness of loading user-plugins

### DIFF
--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -175,8 +175,17 @@ module.exports.loadUserPlugins = function (createSbot, config) {
   //instead of testing all plugins, only load things explicitly
   //enabled in the config
   for(var k in config.plugins) {
-    if(config.plugins[k])
-      createSbot.use(require(path.join(nodeModulesPath, k)))
+    if(config.plugins[k]) {
+      try {
+        var plugin = require(path.join(nodeModulesPath, k))
+        assertSbotPlugin(plugin)
+        if (createSbot.plugins.some(plug => plug.name === plugin.name))
+          throw new Error('already loaded')
+        createSbot.use(plugin)
+      } catch (e) {
+        console.error('Error loading plugin "'+k+'":', e.message)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
- Skip loading a plugin with an already-used name,
  as mentioned in https://github.com/ssbc/scuttlebot/pull/407#issuecomment-305742813
- Add back plugin loading error checking removed in 5653a26d6cfcd9a9cff414d2c291fc24e7a294aa

This addresses https://github.com/ssbc/scuttlebot/pull/407#issuecomment-305731499 so that a user upgrading to the flume branch will not get crashes if they have previously configured user-plugins which are now loaded by scuttlebot core. (these being ssb-ws, ssb-query and ssb-links) - instead, they will get a one-line error message for each, saying that the plugin is already loaded.

I also reenabled wrapping loading the plugins in a try-catch block and checking that the plugin object is valid with assertSbotPlugin, for robustness.