### PR TITLE
merge latest legacy replication into flume from master

### DIFF
--- a/lib/detect-sync.js
+++ b/lib/detect-sync.js
@@ -1,0 +1,48 @@
+module.exports = function detectSync (peerId, upto, toSend, peerHas, onSync) {
+  // HACK: createHistoryStream does not emit sync event, so we don't
+  // know when it switches to live. Do it manually!
+
+  var sync = false
+  var last = (upto.sequence || upto.seq || 0)
+
+  // check sync after 500ms, hopefully we have the info from the peer by then
+  setTimeout(function () {
+    if (peerHas[peerId] && peerHas[peerId][upto.id] != null) {
+      checkSync()
+    } else {
+      // if we get here, the peer hasn't yet asked for this feed, or is not responding
+      // we can assume it doesn't have the feed, so lets call sync
+      broadcastSync()
+    }
+  }, 500)
+
+  return function (msg) {
+    if (msg.sync) {
+      // surprise! This peer actually has a sync event!
+      broadcastSync()
+      return false
+    }
+
+    last = msg.sequence
+    checkSync()
+    return true
+  }
+
+  function checkSync () {
+    if (!sync) {
+      var availableSeq = peerHas[peerId] && peerHas[peerId][upto.id]
+      if (availableSeq === last || availableSeq < toSend[upto.id]) {
+        // we've reached the maximum sequence this server has told us it knows about
+        // or we don't need anything from this server
+        broadcastSync()
+      }
+    }
+  }
+
+  function broadcastSync () {
+    if (!sync) {
+      sync = true
+      onSync && onSync()
+    }
+  }
+}


### PR DESCRIPTION
From https://github.com/ssbc/scuttlebot/pull/407#issuecomment-307357933:

> I just noticed that we are not using the latest legacy replication code. It's fallen back to the old one before we fixed the double pull stream hack that I did for progress sync back in the day.
>
> We should be using this: https://github.com/ssbc/scuttlebot/blob/ea4748e7991a1f992b96faf319cbfd5059639a03/plugins/replicate.js