### PR TITLE
Fix npm bin-script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tape": "~4.0.0"
   },
   "bin": {
-    "sbot": "./sbot.js"
+    "sbot": "./bin.js"
   },
   "scripts": {
     "build": "noderify bin.js > sbot.js",


### PR DESCRIPTION
After installing 10.0.0, the bin-script went empty on me:

```shellsession
npm i -g scuttlebot
cat $(which sbot)
```

Turns out the `bin` script path in `package.json` is off.  From the looks of it, `sbot.js` was renamed to `cli.js` without a corresponding `package.json` change?  I've done that more times than I care to count.

Here is the corresponding `package.json` change.

Thanks to all!