### PR TITLE
don't attempt to connect to peers while migration is running

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,15 @@ var SSB = {
     //remove this, but we'll need something to make a progress bar
     //otherwise people will get confused about what is happening.
 
-    
+
 
     return {
       id                       : feed.id,
       keys                     : opts.keys,
+
+      ready                    : function () {
+        return ssb.ready.value
+      },
 
       progress                 : function () {
         return ssb.progress
@@ -158,6 +162,3 @@ module.exports = SecretStack({
   appKey: require('./lib/ssb-cap')
 })
 .use(SSB)
-
-
-

--- a/plugins/gossip/schedule.js
+++ b/plugins/gossip/schedule.js
@@ -144,6 +144,10 @@ function (gossip, config, server) {
     connecting = true
     setTimeout(function () {
       connecting = false
+
+      // don't attempt to connect while migration is running
+      if (!server.ready()) return
+
       var ts = Date.now()
       var peers = gossip.peers()
 
@@ -239,4 +243,3 @@ exports.isLocal = isLocal
 exports.isFriend = isFriend
 exports.isConnectedOrConnecting = isConnect
 exports.select = select
-


### PR DESCRIPTION
see [%/+J9b8I4bDkw+myccUxGzpj28vyZ78TTkeBCdVWB26w=.sha256](https://viewer.scuttlebot.io/%25%2F%2BJ9b8I4bDkw%2BmyccUxGzpj28vyZ78TTkeBCdVWB26w%3D.sha256)

> ## Overloaded Scuttlebot
> 
> The other issue only affected users who were on the same wifi. Turns out scuttlebot still tries to connect to local peers before the migration has completed. This causes it to try and replicate all the data at the same time as upgrading it, making everything freak out and go bad.
>
> We couldn't get it to work properly until wifi was turned off.
>
> We need suspend gossip while the migration is taking place.

Then @dominictarr replied:

> There is a db.ready observable that is set to false while migration is incomplete. Gossip can check that.