### PR TITLE
gossip: debounce has-network for better windows performance

### DIFF
--- a/lib/has-network-debounced.js
+++ b/lib/has-network-debounced.js
@@ -1,0 +1,12 @@
+var hasNetwork = require('has-network')
+
+var lastCheck = 0
+var lastValue = null
+
+module.exports = function hasNetworkDebounced () {
+  if (lastCheck + 1e3 < Date.now()) {
+    lastCheck = Date.now()
+    lastValue = hasNetwork()
+  }
+  return lastValue
+}

--- a/plugins/gossip/schedule.js
+++ b/plugins/gossip/schedule.js
@@ -2,7 +2,7 @@
 var ip = require('ip')
 var onWakeup = require('on-wakeup')
 var onNetwork = require('on-change-network')
-var hasNetwork = require('has-network')
+var hasNetwork = require('../../lib/has-network-debounced')
 
 var pull = require('pull-stream')
 


### PR DESCRIPTION
I have been trying to figure out why Patchwork runs so badly on my girlfriend's computer. It's an old thinkpad from 2011 running Windows 8. Finally hit a breakthrough in the profiler:

![windows-misery](https://user-images.githubusercontent.com/66834/27717144-65acb5aa-5d97-11e7-88fd-f093844ac002.png)

Each connection attempt is blocking for more than 2 seconds!! Tracked this down to many calls to `hasNetwork`. It was being called 100s of times a second. And apparently it is a slow blocking command on this machine. Haven't investigated why it is so slow, instead I fixed it the quick and dirty way.

**This PR adds a 1 second debounce to all `hasNetwork` requests. And suddenly everything  runs beautifully on that machine.**

cc @dominictarr 