### PR TITLE
fix db.ready check for local peers

### DIFF
--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -276,6 +276,10 @@ module.exports = {
     //get current state
 
     server.on('rpc:connect', function (rpc, isClient) {
+
+      // if we're not ready, close this connection immediately
+      if (!server.ready() && rpc.id !== server.id) return rpc.close()
+
       var peer = getPeer(rpc.id)
       //don't track clients that connect, but arn't considered peers.
       //maybe we should though?

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -241,6 +241,7 @@ module.exports = {
         var index = peers.indexOf(peer)
         if (~index) {
           peers.splice(index, 1)
+          notify({ type: 'remove', peer: peer })
         }
       },
       ping: function (opts) {

--- a/plugins/replicate/legacy.js
+++ b/plugins/replicate/legacy.js
@@ -229,6 +229,8 @@ module.exports = function (sbot, notify, config) {
   sbot.on('rpc:connect', function(rpc) {
     // this is the cli client, just ignore.
     if(rpc.id === sbot.id) return
+    if (!sbot.ready()) return
+
     var errorsSeen = {}
     //check for local peers, or manual connections.
     localPeers()


### PR DESCRIPTION
Noticed that while adding the `db.ready` check on gossip scheduling solved most of the _replicate while migrating_ bugs, other machines can still connect to you, and you'll try to replicate with them.

**This PR adds some more `db.ready` checks on replication. Will immediately disconnect from a peer if it tries to connect in this time.** It also adds a missing `notify()` case for removed local peers.

Issue in patchwork: ssbc/patchwork#567

cc @dominictarr 