### PR TITLE
remove blocking hasNetwork

### DIFF
--- a/plugins/gossip/schedule.js
+++ b/plugins/gossip/schedule.js
@@ -2,7 +2,6 @@
 var ip = require('ip')
 var onWakeup = require('on-wakeup')
 var onNetwork = require('on-change-network')
-var hasNetwork = require('../../lib/has-network-debounced')
 
 var pull = require('pull-stream')
 
@@ -30,17 +29,6 @@ function maxStateChange (M, e) {
 function peerNext(peer, opts) {
   return (peer.stateChange|0) + delay(peer.failure|0, opts.factor, opts.max)
 }
-
-
-//detect if not connected to wifi or other network
-//(i.e. if there is only localhost)
-
-function isOffline (e) {
-  if(ip.isLoopback(e.host) || e.host == 'localhost') return false
-  return !hasNetwork()
-}
-
-var isOnline = not(isOffline)
 
 function isLocal (e) {
   // don't rely on private ip address, because
@@ -130,7 +118,7 @@ function (gossip, config, server) {
     }
 
     //will return [] if the quota is full
-    var selected = select(peers, ts, and(filter, isOnline), opts)
+    var selected = select(peers, ts, and(filter), opts)
     selected
       .forEach(function (peer) {
         gossip.connect(peer)


### PR DESCRIPTION
Something has been seriously wrong with scuttlebot, and my instinct was telling me that it had something to do with gossip. After a conversation with a Benjamin Franklin statue about non-blocking I/O in JS, I decided to poke around a little bit in the code. I discovered `hasNetworkdebounced`, which was new to me. I tracked back the pull, and found https://github.com/ssbc/scuttlebot/pull/424 -- which pointed to a _serious problem_, which is the whole application is blocking every time it checks to see if the Internet is up.

It occurred to me that checking to see if the Internet is up is I/O, which is slow and thus could block Node.js. After this realization, I delete-key-programmed a few lines of code, and now scuttlebot is working a lot better. I can even gossip with my pub now!

I think we should merge this until we figure out how to check and see if the connection is up without blocking the entire app in the process.