### PR TITLE
prevent gossip scheduling while downloading messages

### DIFF
--- a/plugins/gossip/schedule.js
+++ b/plugins/gossip/schedule.js
@@ -137,6 +137,13 @@ function (gossip, config, server) {
       })
   }
 
+  function currentlyDownloading () {
+    // don't schedule gossip if currently downloading messages
+    if (server.lastMessageAt && server.lastMessageAt > Date.now() - 500) {
+      console.log('skip gossip')
+      return true
+    }
+  }
 
   var connecting = false
   function connections () {
@@ -146,7 +153,7 @@ function (gossip, config, server) {
       connecting = false
 
       // don't attempt to connect while migration is running
-      if (!server.ready()) return
+      if (!server.ready() || currentlyDownloading()) return
 
       var ts = Date.now()
       var peers = gossip.peers()
@@ -247,7 +254,3 @@ exports.isLocal = isLocal
 exports.isFriend = isFriend
 exports.isConnectedOrConnecting = isConnect
 exports.select = select
-
-
-
-


### PR DESCRIPTION
The current PR contains a quick hack to prevent gossip from being scheduled while feed download is taking place. It detects this by checking to see if a message was downloaded in the last 500ms.

Currently it uses a nasty global whacked on the `sbot` to share the state out of legacy replication into gossip scheduling.

---

But the important thing is just how much this improves onboarding performance. It no longer crashes! Completes in a few minutes instead of mysterious indefinite locking.

See https://github.com/ssbc/patchwork/issues/631 for more context.

cc @dominictarr @clehner @ahdinosaur  