### PR TITLE
fix updating from local peers that you don't follow

### DIFF
--- a/plugins/replicate/legacy.js
+++ b/plugins/replicate/legacy.js
@@ -196,7 +196,7 @@ module.exports = function (sbot, notify, config) {
   function localPeers () {
     if(!sbot.gossip) return
     sbot.gossip.peers().forEach(function (e) {
-      if (e.source === 'local' && toSend[e.key] == null)
+      if (e.source === 'local')
         request(e.key)
     })
   }


### PR DESCRIPTION
The `toSend[id] == null` is an old check that is unnecessary after adding the `e.source === 'local'`. It stops replication from requesting feeds from a local peer after restart if you have not followed them, which is really not what you want.

**This PR removes that broken check, and now local peers replicate their own feed as expected!**

Gonna roll this out in the new version of patchwork about to be released.

fixes #437