### PR TITLE
Immediately stop loading plugin if it is falsey

### DIFF
--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -183,10 +183,8 @@ module.exports.loadUserPlugins = function (createSbot, config) {
     if (createSbot.plugins.some(plug => plug.name === name))
       throw new Error('already loaded plugin named:'+name)
       var plugin = require(path.join(nodeModulesPath, module_name))
-      if(!plugin)
-        return
-      if(plugin.name !== name)
-        throw new Error('plugin at:'+module_name+' expected name:'+name+' but had:'+plugin.name)
+      if(!plugin || plugin.name !== name)
+        throw new Error('plugin at:'+module_name+' expected name:'+name+' but had:'+(plugin||{}).name)
       assertSbotPlugin(plugin)
       createSbot.use(plugin)
     }

--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -183,6 +183,8 @@ module.exports.loadUserPlugins = function (createSbot, config) {
     if (createSbot.plugins.some(plug => plug.name === name))
       throw new Error('already loaded plugin named:'+name)
       var plugin = require(path.join(nodeModulesPath, module_name))
+      if(!plugin)
+        return
       if(plugin.name !== name)
         throw new Error('plugin at:'+module_name+' expected name:'+name+' but had:'+plugin.name)
       assertSbotPlugin(plugin)


### PR DESCRIPTION
Don't attempt to access a property on a plugin that has returned `undefined`.

Why this was a problem for me:
```
$ sbot plugins.install blob
$ sbot server
/home/.nvm/versions/node/v6.11.3/lib/node_modules/scuttlebot/plugins/plugins.js:187
        throw new Error('plugin at:'+module_name+' expected name:'+name+' but had:'+plugin.name)
                                                                                          ^

TypeError: Cannot read property 'name' of undefined
    at Object.module.exports.loadUserPlugins (/home/.nvm/versions/node/v6.11.3/lib/node_modules/scuttlebot/plugins/plugins.js:187:91)
    at Object.<anonymous> (/home/.nvm/versions/node/v6.11.3/lib/node_modules/scuttlebot/bin.js:54:32)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
    at startup (bootstrap_node.js:149:9)
```

I looked into the `node_modules` folder and realized that this wasn't a scuttlebot plugin at all.

Perhaps a more specific failure is necessary to capture this case.