### PR TITLE
replicate progress: don't include disconnected peers in incomplete count

### DIFF
--- a/plugins/replicate/legacy.js
+++ b/plugins/replicate/legacy.js
@@ -80,7 +80,7 @@ module.exports = function (sbot, notify, config) {
     var legacyToRecv = {}
 
     Object.keys(pendingFeedsForPeer).forEach(function (peerId) {
-      if (pendingFeedsForPeer[peerId]) {
+      if (pendingFeedsForPeer[peerId] && pendingFeedsForPeer[peerId].size) {
         Object.keys(toSend).forEach(function (feedId) {
           if (peerHas[peerId] && peerHas[peerId][feedId]) {
             if (peerHas[peerId][feedId] > toSend[feedId]) {
@@ -88,9 +88,7 @@ module.exports = function (sbot, notify, config) {
             }
           }
         })
-        if (pendingFeedsForPeer[peerId].size) {
-          pendingPeers[peerId] = pendingFeedsForPeer[peerId].size
-        }
+        pendingPeers[peerId] = pendingFeedsForPeer[peerId].size
       }
     })
 
@@ -350,4 +348,3 @@ module.exports = function (sbot, notify, config) {
     changes: notify.listen
   }
 }
-


### PR DESCRIPTION
Fixes stuck downloading message progress in patchwork.

This (as far as I can possible see) is absolutely safe to merge and only affects Patchwork.

If no one complains within the next 24 hrs, I will merge it! I am already running this patch in patchwork (latest master) but it would be nice to get it into mainbot.

cc @dominictarr 