### PR TITLE
Bring package-lock.json up-to-date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,330 @@
 {
   "name": "scuttlebot",
-  "version": "10.4.6",
+  "version": "10.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "async-single": {
+    "abstract-leveldown": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+      "requires": {
+        "xtend": "3.0.0"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
+    "aligned-block-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.2.tgz",
+      "integrity": "sha1-SpFo1f7+Xi9SWUncVaSqCZA7MtQ=",
+      "requires": {
+        "hashlru": "2.2.0",
+        "int53": "0.2.4",
+        "mkdirp": "0.5.1",
+        "obv": "0.0.0",
+        "uint48be": "1.0.2"
+      },
+      "dependencies": {
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        }
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "append-batch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
+      "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arraybuffer-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arraybuffer-base64/-/arraybuffer-base64-1.0.0.tgz",
+      "integrity": "sha1-/QIXuiuo1IYzZj+kOoCTdoAp2jA="
+    },
+    "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.1.tgz",
-      "integrity": "sha1-I9rbKpEDi7T5Bd7v2O31bgQ1zGw="
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-single": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
+    },
+    "async-write": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz",
+      "integrity": "sha1-HnYoF9hJzkS/rAeSWkIDZ4cGGxU="
     },
     "atomic-file": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz",
       "integrity": "sha1-bDZlj2xOzjP7o4d3MefCX8gpmbs="
     },
+    "attach-ware": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
+      "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
+      "requires": {
+        "unherit": "1.1.0"
+      }
+    },
+    "bail": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
+      "dev": true
+    },
     "bash-color": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
       "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
     },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "binary-search": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz",
+      "integrity": "sha1-iMm3vStyIdNS2njsiH9a8lSeTeI="
+    },
+    "binary-xhr": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/binary-xhr/-/binary-xhr-0.0.2.tgz",
+      "integrity": "sha1-IQywda0XeqRIpu+iiMEKiZw7OYc=",
+      "requires": {
+        "inherits": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+          "integrity": "sha1-OOGXUoW/H3upyE2hArsSdxMirEg="
+        }
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "bl": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "blake2s": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.0.1.tgz",
+      "integrity": "sha1-FZiCKjIOzmqkAbqYKVT4L2GwzXs="
+    },
+    "bops": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-0.1.1.tgz",
+      "integrity": "sha1-Bi4CqNqoAfoQ8uXb5nQM/4Af4X4=",
+      "dev": true,
+      "requires": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
     "broadcast-stream": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.1.tgz",
+      "integrity": "sha1-jkta0ELS2uDkhg6YHbI+IMrPeqA="
+    },
+    "browser-split": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.0.0.tgz",
-      "integrity": "sha1-3LPwYSKW/nIJbiX+hmWuyZhl4b8="
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
+      "requires": {
+        "bytewise-core": "1.2.3",
+        "typewise": "1.0.3"
+      }
+    },
+    "bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
+      "requires": {
+        "typewise-core": "1.2.0"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "cat-names": {
       "version": "1.0.2",
@@ -32,376 +334,169 @@
       "requires": {
         "meow": "3.7.0",
         "unique-random-array": "1.0.0"
-      },
-      "dependencies": {
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-          "dev": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "dev": true,
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "unique-random": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
-          "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ=",
-          "dev": true
-        },
-        "unique-random-array": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
-          "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
-          "dev": true,
-          "requires": {
-            "unique-random": "1.0.0"
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        }
+      }
+    },
+    "ccount": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "character-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
+    },
+    "character-entities-html4": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
+    },
+    "chloride": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.8.tgz",
+      "integrity": "sha1-6/mos8qJp0R8NgOW2t+BfIqY1Zk=",
+      "requires": {
+        "is-electron": "2.1.0",
+        "sodium-browserify": "1.2.1",
+        "sodium-browserify-tweetnacl": "0.2.3",
+        "sodium-chloride": "1.1.0",
+        "sodium-native": "2.0.1"
+      }
+    },
+    "chloride-test": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
+      "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
+      "requires": {
+        "json-buffer": "2.0.11"
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "class-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "co": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "cont": {
       "version": "1.0.3",
@@ -411,58 +506,61 @@
         "continuable": "1.2.0",
         "continuable-para": "1.2.0",
         "continuable-series": "1.2.0"
+      }
+    },
+    "continuable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
+      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
+    },
+    "continuable-hash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
+      "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
+      "requires": {
+        "continuable": "1.1.8"
       },
       "dependencies": {
         "continuable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
-          "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
-        },
-        "continuable-hash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
-          "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
-          "requires": {
-            "continuable": "1.1.8"
-          },
-          "dependencies": {
-            "continuable": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-              "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
-            }
-          }
-        },
-        "continuable-list": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
-          "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
-          "requires": {
-            "continuable": "1.1.8"
-          },
-          "dependencies": {
-            "continuable": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-              "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
-            }
-          }
-        },
-        "continuable-para": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
-          "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
-          "requires": {
-            "continuable-hash": "0.1.4",
-            "continuable-list": "0.1.6"
-          }
-        },
-        "continuable-series": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
-          "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
         }
       }
+    },
+    "continuable-list": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
+      "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
+      "requires": {
+        "continuable": "1.1.8"
+      },
+      "dependencies": {
+        "continuable": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+        }
+      }
+    },
+    "continuable-para": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
+      "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
+      "requires": {
+        "continuable-hash": "0.1.4",
+        "continuable-list": "0.1.6"
+      }
+    },
+    "continuable-series": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
+      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -472,59 +570,67 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "requires": {
-            "shebang-regex": "1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        }
       }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deferred-leveldown": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+      "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+      "requires": {
+        "abstract-leveldown": "0.12.4"
+      }
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detab": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
+      "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
+      "requires": {
+        "repeat-string": "1.6.1"
+      }
     },
     "dog-names": {
       "version": "1.0.2",
@@ -534,384 +640,259 @@
       "requires": {
         "meow": "3.7.0",
         "unique-random-array": "1.0.0"
-      },
-      "dependencies": {
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-          "dev": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "dev": true,
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "unique-random": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
-          "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ=",
-          "dev": true
-        },
-        "unique-random-array": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
-          "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
-          "dev": true,
-          "requires": {
-            "unique-random": "1.0.0"
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        }
       }
+    },
+    "ed2curve": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+      "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+    },
+    "emoji-named-characters": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz",
+      "integrity": "sha1-zes20OZgAsS5178d+8Ohmft9QJs="
+    },
+    "emoji-server": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
+      "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
+      "requires": {
+        "emoji-named-characters": "1.0.2"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "requires": {
+        "prr": "0.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "expand-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
     },
     "explain-error": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
       "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
-    "flumeview-reduce": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.3.tgz",
-      "integrity": "sha512-fAu2R81ycHdXvt4sZV+CT3cQeMFxrizXAGjsUONctOZHM0SHpNvUEkLZlN5n8C1/6D8nD1T9QnMQIscTtRgv+g==",
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend.js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz",
+      "integrity": "sha1-D5x6gaHyCLcD6wwxMf5XFqxuzRU="
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "async-single": "1.0.1",
-        "atomic-file": "0.3.0",
+        "is-extglob": "1.0.0"
+      }
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flumecodec": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
+      "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+      "requires": {
+        "level-codec": "6.2.0"
+      }
+    },
+    "flumedb": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.2.tgz",
+      "integrity": "sha1-bqeQFvN5kkISa0sOsCnx86HeWoU=",
+      "requires": {
+        "cont": "1.0.3",
+        "explain-error": "1.0.4",
+        "obv": "0.0.1",
+        "pull-cont": "0.0.0",
+        "pull-stream": "3.6.1"
+      }
+    },
+    "flumelog-offset": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.2.6.tgz",
+      "integrity": "sha512-hE0vWDqFMjMhXROWEqEb9OFr6VFSjB8lvu4hgeQO9WxI9OqKVl0TD48Mf3NeTKrtXqHyxkfzQwMSw6fgKKf1lA==",
+      "requires": {
+        "aligned-block-file": "1.1.2",
+        "append-batch": "0.0.1",
+        "explain-error": "1.0.4",
+        "hashlru": "2.2.0",
+        "int53": "0.2.4",
+        "looper": "4.0.0",
+        "ltgt": "2.2.0",
+        "obv": "0.0.1",
+        "pull-cursor": "2.1.3",
+        "pull-looper": "1.0.0",
+        "uint48be": "1.0.2"
+      }
+    },
+    "flumeview-hashtable": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.3.tgz",
+      "integrity": "sha1-0qn6Fkn1fvaNG4nrTEO/sXJDeWc=",
+      "requires": {
+        "async-single": "1.0.5",
+        "atomic-file": "1.1.3",
+        "obv": "0.0.1",
+        "pull-stream": "3.6.1"
+      },
+      "dependencies": {
+        "atomic-file": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.3.tgz",
+          "integrity": "sha512-T0T/st8MAsbBm1PKBMP+PgKPYlPB+EFak0MbFrJZwzQ3QcgU9kq55BbPNgFnJhHi/pmrJvSQaio6KJUUupDuJg=="
+        }
+      }
+    },
+    "flumeview-level": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-2.1.0.tgz",
+      "integrity": "sha1-RogRF9iyxg1CYEBc63oY+60m4s4=",
+      "requires": {
+        "bytewise": "1.1.0",
+        "explain-error": "1.0.4",
+        "level": "1.7.0",
+        "ltgt": "2.2.0",
+        "mkdirp": "0.5.1",
+        "obv": "0.0.0",
+        "pull-level": "2.0.3",
+        "pull-paramap": "1.2.2",
+        "pull-stream": "3.6.1",
+        "pull-write": "1.1.4"
+      },
+      "dependencies": {
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        }
+      }
+    },
+    "flumeview-query": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-3.0.7.tgz",
+      "integrity": "sha1-52wNcuxF5irrqho2yUYeHHbOgqA=",
+      "requires": {
+        "explain-error": "1.0.4",
+        "flumeview-level": "2.1.0",
+        "map-filter-reduce": "3.0.3",
+        "pull-flatmap": "0.0.1",
+        "pull-paramap": "1.2.2",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "3.6.1"
+      },
+      "dependencies": {
+        "map-filter-reduce": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.0.3.tgz",
+          "integrity": "sha1-ihC4bjRlut13YBqZV9velLmNYKo=",
+          "requires": {
+            "binary-search": "1.3.2",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "3.6.1",
+            "typewiselite": "1.0.0"
+          }
+        }
+      }
+    },
+    "flumeview-reduce": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.9.tgz",
+      "integrity": "sha1-WGy0rGpevgeMY+GQHksQf315TzA=",
+      "requires": {
+        "async-single": "1.0.5",
+        "atomic-file": "1.1.3",
         "deep-equal": "1.0.1",
         "flumecodec": "0.0.0",
         "obv": "0.0.0",
@@ -920,22 +901,9 @@
       },
       "dependencies": {
         "atomic-file": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.3.0.tgz",
-          "integrity": "sha1-MVxVJH5MCQmoofnJ0MKP8iHIp5k="
-        },
-        "flumecodec": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
-          "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
-          "requires": {
-            "level-codec": "6.2.0"
-          }
-        },
-        "level-codec": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.3.tgz",
+          "integrity": "sha512-T0T/st8MAsbBm1PKBMP+PgKPYlPB+EFak0MbFrJZwzQ3QcgU9kq55BbPNgFnJhHi/pmrJvSQaio6KJUUupDuJg=="
         },
         "obv": {
           "version": "0.0.0",
@@ -944,11 +912,102 @@
         }
       }
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "globby": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "6.0.4",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphreduce": {
       "version": "3.0.4",
@@ -958,10 +1017,75 @@
         "statistics": "3.3.0"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "has-network": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz",
       "integrity": "sha1-Pup7RMqpYBeXEkvouonSKMQQFJk="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hashlru": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.0.tgz",
+      "integrity": "sha1-eTpYlD+QKupXgXfXsDNfE/JpS3E="
+    },
+    "he": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
+      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
+    },
+    "hoox": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
+      "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "html-element": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/html-element/-/html-element-1.3.0.tgz",
+      "integrity": "sha1-117LXa6HSx3mCgv4eUu9GYTQ8gk=",
+      "requires": {
+        "class-list": "0.1.1"
+      }
+    },
+    "hyperfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyperfile/-/hyperfile-1.1.1.tgz",
+      "integrity": "sha1-czvGxmj7miFgCMTzNlMfiU28efM=",
+      "requires": {
+        "hyperscript": "1.4.7"
+      }
+    },
+    "hyperprogress": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hyperprogress/-/hyperprogress-0.1.1.tgz",
+      "integrity": "sha1-5TDGFjqisSg+rBkhkiJadi8Jw0Q="
+    },
+    "hyperscript": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-1.4.7.tgz",
+      "integrity": "sha1-HyPYgPhDbKrCW5GnrDl0e4mnJhg=",
+      "requires": {
+        "browser-split": "0.0.0",
+        "class-list": "0.1.1",
+        "html-element": "1.3.0"
+      }
     },
     "idb-wrapper": {
       "version": "1.4.1",
@@ -969,16 +1093,269 @@
       "integrity": "sha1-IO13J9UV11vv18OAqLlkAMURRWw=",
       "dev": true
     },
+    "increment-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
+      "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "int53": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
+      "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
+    },
     "ip": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
       "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-electron": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
+      "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-domain": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.5.tgz",
+      "integrity": "sha1-SOcDGfy0MAkjbpazf5hDiJzntRM="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbuffer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
       "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s=",
       "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
+    "json-buffer": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "level": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
+      "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
+      "requires": {
+        "level-packager": "1.2.1",
+        "leveldown": "1.7.2"
+      }
+    },
+    "level-codec": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "requires": {
+        "errno": "0.1.4"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "requires": {
+        "inherits": "2.0.3",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
+      }
     },
     "level-js": {
       "version": "2.1.6",
@@ -995,33 +1372,10 @@
         "xtend": "2.1.2"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "dev": true,
-          "requires": {
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-              "dev": true
-            }
-          }
-        },
         "deep-equal": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
           "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-          "dev": true
-        },
-        "defined": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
           "dev": true
         },
         "glob": {
@@ -1033,12 +1387,6 @@
             "inherits": "2.0.3",
             "minimatch": "0.3.0"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
         },
         "lru-cache": {
           "version": "2.7.3",
@@ -1062,15 +1410,6 @@
             "sigmund": "1.0.1"
           }
         },
-        "resumer": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-          "dev": true,
-          "requires": {
-            "through": "2.3.8"
-          }
-        },
         "tape": {
           "version": "2.10.3",
           "resolved": "https://registry.npmjs.org/tape/-/tape-2.10.3.tgz",
@@ -1086,12 +1425,6 @@
             "through": "2.3.8"
           }
         },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
         "xtend": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
@@ -1099,6 +1432,45 @@
           "dev": true,
           "requires": {
             "object-keys": "0.4.0"
+          }
+        }
+      }
+    },
+    "level-live-stream": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/level-live-stream/-/level-live-stream-1.4.12.tgz",
+      "integrity": "sha1-87jKj4n8Ec+y4P2rZJhOzs1aUhE=",
+      "requires": {
+        "level-sublevel": "6.6.1",
+        "pull-level": "2.0.3",
+        "pull-stream-to-stream": "1.2.6"
+      },
+      "dependencies": {
+        "level-sublevel": {
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
+          "integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
+          "requires": {
+            "bytewise": "1.1.0",
+            "levelup": "0.19.1",
+            "ltgt": "2.1.3",
+            "pull-level": "2.0.3",
+            "pull-stream": "3.6.1",
+            "typewiselite": "1.0.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "ltgt": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+        },
+        "pull-stream-to-stream": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.2.6.tgz",
+          "integrity": "sha1-3Z+jcy7bPRbmfNHyJLyjim1XSMc=",
+          "requires": {
+            "pull-core": "1.1.0"
           }
         }
       }
@@ -1113,191 +1485,10 @@
         "pull-stream": "2.26.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "requires": {
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "bl": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-          "requires": {
-            "readable-stream": "1.0.34"
-          }
-        },
-        "bytewise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-          "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
-          }
-        },
-        "bytewise-core": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "deferred-leveldown": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-          "requires": {
-            "abstract-leveldown": "0.12.4"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "requires": {
-            "prr": "0.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-live-stream": {
-          "version": "1.4.12",
-          "resolved": "https://registry.npmjs.org/level-live-stream/-/level-live-stream-1.4.12.tgz",
-          "integrity": "sha1-87jKj4n8Ec+y4P2rZJhOzs1aUhE=",
-          "requires": {
-            "level-sublevel": "6.6.1",
-            "pull-level": "2.0.3",
-            "pull-stream-to-stream": "1.2.6"
-          },
-          "dependencies": {
-            "pull-level": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.3.tgz",
-              "integrity": "sha1-lQBjXiV5Rdb+7eGF9deiR3NFWxc=",
-              "requires": {
-                "level-post": "1.0.5",
-                "pull-cat": "1.1.11",
-                "pull-live": "1.0.1",
-                "pull-pushable": "2.1.1",
-                "pull-stream": "3.6.1",
-                "pull-window": "2.1.4",
-                "stream-to-pull-stream": "1.7.2"
-              }
-            },
-            "pull-stream": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
-              "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
-            }
-          }
-        },
-        "level-post": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-          "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
-          "requires": {
-            "ltgt": "2.1.3"
-          }
-        },
-        "level-sublevel": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-          "integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
-          "requires": {
-            "bytewise": "1.1.0",
-            "levelup": "0.19.1",
-            "ltgt": "2.1.3",
-            "pull-level": "2.0.3",
-            "pull-stream": "3.6.1",
-            "typewiselite": "1.0.0",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "pull-level": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.3.tgz",
-              "integrity": "sha1-lQBjXiV5Rdb+7eGF9deiR3NFWxc=",
-              "requires": {
-                "level-post": "1.0.5",
-                "pull-cat": "1.1.11",
-                "pull-live": "1.0.1",
-                "pull-pushable": "2.1.1",
-                "pull-stream": "3.6.1",
-                "pull-window": "2.1.4",
-                "stream-to-pull-stream": "1.7.2"
-              }
-            },
-            "pull-stream": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
-              "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
-            }
-          }
-        },
-        "levelup": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-          "requires": {
-            "bl": "0.8.2",
-            "deferred-leveldown": "0.2.0",
-            "errno": "0.1.4",
-            "prr": "0.0.0",
-            "readable-stream": "1.0.34",
-            "semver": "5.1.1",
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "looper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
-        },
-        "ltgt": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-        },
-        "prr": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-        },
         "pull-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-          "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.0.0.tgz",
+          "integrity": "sha1-4OuTkY36cJY+0J429j2qFbdrOKQ="
         },
         "pull-level": {
           "version": "1.2.0",
@@ -1310,54 +1501,23 @@
             "pull-stream": "2.26.1",
             "pull-window": "2.1.4",
             "stream-to-pull-stream": "1.3.1"
-          },
-          "dependencies": {
-            "pull-core": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.0.0.tgz",
-              "integrity": "sha1-4OuTkY36cJY+0J429j2qFbdrOKQ="
-            },
-            "pull-pushable": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-1.1.4.tgz",
-              "integrity": "sha1-dmTWdB9yaH71yJ9TO3hoLz3pog4=",
-              "requires": {
-                "pull-stream": "2.18.3"
-              },
-              "dependencies": {
-                "pull-stream": {
-                  "version": "2.18.3",
-                  "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.18.3.tgz",
-                  "integrity": "sha1-egeWIjTXV5yQiGDbjCf380/UUAA=",
-                  "requires": {
-                    "pull-core": "1.0.0"
-                  }
-                }
-              }
-            },
-            "stream-to-pull-stream": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.3.1.tgz",
-              "integrity": "sha1-9b6b4PHpS7PRrmaL/46SUbhabG4=",
-              "requires": {
-                "pull-core": "1.0.0"
-              }
-            }
           }
         },
-        "pull-live": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+        "pull-pushable": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-1.1.4.tgz",
+          "integrity": "sha1-dmTWdB9yaH71yJ9TO3hoLz3pog4=",
           "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
+            "pull-stream": "2.18.3"
           },
           "dependencies": {
             "pull-stream": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
-              "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
+              "version": "2.18.3",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.18.3.tgz",
+              "integrity": "sha1-egeWIjTXV5yQiGDbjCf380/UUAA=",
+              "requires": {
+                "pull-core": "1.0.0"
+              }
             }
           }
         },
@@ -1367,68 +1527,86 @@
           "integrity": "sha1-S/JVneh7ivL1uWtxkNLuQxyh5Rk=",
           "requires": {
             "pull-core": "1.1.0"
+          },
+          "dependencies": {
+            "pull-core": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
+              "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+            }
           }
         },
-        "pull-stream-to-stream": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.2.6.tgz",
-          "integrity": "sha1-3Z+jcy7bPRbmfNHyJLyjim1XSMc=",
+        "stream-to-pull-stream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.3.1.tgz",
+          "integrity": "sha1-9b6b4PHpS7PRrmaL/46SUbhabG4=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "1.0.0"
+          }
+        }
+      }
+    },
+    "level-packager": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
+      "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
+      "requires": {
+        "levelup": "1.3.9"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "requires": {
+            "xtend": "4.0.1"
           }
         },
-        "pull-window": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-          "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
           "requires": {
-            "looper": "2.0.0"
+            "abstract-leveldown": "2.6.3"
           }
         },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+        "level-codec": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "deferred-leveldown": "1.2.2",
+            "level-codec": "7.0.1",
+            "level-errors": "1.0.5",
+            "level-iterator-stream": "1.3.1",
+            "prr": "1.0.1",
+            "semver": "5.4.1",
+            "xtend": "4.0.1"
           }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
         "semver": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "typewise": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "typewise-core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
-        },
-        "typewiselite": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         }
+      }
+    },
+    "level-post": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
+      "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
+      "requires": {
+        "ltgt": "2.2.0"
       }
     },
     "level-sublevel": {
@@ -1445,48 +1623,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "dev": true,
-          "requires": {
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-              "dev": true
-            }
-          }
-        },
-        "base64-js": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-          "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
-          "dev": true
-        },
-        "bl": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34"
-          }
-        },
-        "bops": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/bops/-/bops-0.1.1.tgz",
-          "integrity": "sha1-Bi4CqNqoAfoQ8uXb5nQM/4Af4X4=",
-          "dev": true,
-          "requires": {
-            "base64-js": "0.0.2",
-            "to-utf8": "0.0.1"
-          }
-        },
         "bytewise": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-0.7.1.tgz",
@@ -1496,75 +1632,10 @@
             "bops": "0.1.1"
           }
         },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "deferred-leveldown": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-          "dev": true,
-          "requires": {
-            "abstract-leveldown": "0.12.4"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "dev": true,
-          "requires": {
-            "prr": "0.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "levelup": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-          "dev": true,
-          "requires": {
-            "bl": "0.8.2",
-            "deferred-leveldown": "0.2.0",
-            "errno": "0.1.4",
-            "prr": "0.0.0",
-            "readable-stream": "1.0.34",
-            "semver": "5.1.1",
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-              "dev": true
-            }
-          }
-        },
         "ltgt": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.0.0.tgz",
           "integrity": "sha1-tA7R4zfK9XfAqWP5z/vGgDGACcI=",
-          "dev": true
-        },
-        "prr": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
           "dev": true
         },
         "pull-core": {
@@ -1581,48 +1652,6 @@
           "requires": {
             "pull-core": "1.0.0"
           }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "semver": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "to-utf8": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-          "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
-          "dev": true
-        },
-        "typewiselite": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -1634,7 +1663,7 @@
       "requires": {
         "level": "1.7.0",
         "level-js": "2.1.6",
-        "leveldown": "1.8.0",
+        "leveldown": "1.7.2",
         "levelup": "1.3.9",
         "memdown": "1.0.0",
         "mkdirp": "0.5.1",
@@ -1652,153 +1681,6 @@
             "xtend": "4.0.1"
           }
         },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-          "dev": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-          "dev": true
-        },
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
         "deferred-leveldown": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
@@ -1807,72 +1689,6 @@
           "requires": {
             "abstract-leveldown": "2.6.3"
           }
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "dev": true,
-          "requires": {
-            "prr": "0.0.0"
-          },
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-              "dev": true
-            }
-          }
-        },
-        "expand-template": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-          "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
-          "dev": true
-        },
-        "fast-future": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo=",
-          "dev": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-          "dev": true
         },
         "glob": {
           "version": "4.5.3",
@@ -1886,149 +1702,11 @@
             "once": "1.4.0"
           }
         },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "level": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-          "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-          "dev": true,
-          "requires": {
-            "level-packager": "1.2.1",
-            "leveldown": "1.7.2"
-          },
-          "dependencies": {
-            "leveldown": {
-              "version": "1.7.2",
-              "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-              "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-              "dev": true,
-              "requires": {
-                "abstract-leveldown": "2.6.3",
-                "bindings": "1.2.1",
-                "fast-future": "1.0.2",
-                "nan": "2.6.2",
-                "prebuild-install": "2.2.2"
-              }
-            }
-          }
-        },
         "level-codec": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
           "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
           "dev": true
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "dev": true,
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "dev": true,
-          "requires": {
-            "levelup": "1.3.9"
-          }
-        },
-        "leveldown": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.8.0.tgz",
-          "integrity": "sha512-4r02OXouz24Sxs+i8ZNgDZxrRMRZq6BWS7pj6vjKEb8DFnEsveyaPIxF9Y3uHL5+jftWUDsmThT90epRrC6aGw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abstract-leveldown": "2.7.0",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.7.0",
-            "prebuild-install": "2.2.2"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "2.7.0",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.0.tgz",
-              "integrity": "sha512-maam3ZrTeORbXKEJUeJZkYOsorEwr060WitXuQlUuIFlg0RofyyHts49wtaVmShJ6l0wEWB0ZtPhf6QYBA7D2w==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "xtend": "4.0.1"
-              }
-            },
-            "bindings": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-              "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-              "dev": true,
-              "optional": true
-            },
-            "nan": {
-              "version": "2.7.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-              "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-              "dev": true,
-              "optional": true
-            }
-          }
         },
         "levelup": {
           "version": "1.3.9",
@@ -2054,130 +1732,11 @@
             "brace-expansion": "1.1.8"
           }
         },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-          "dev": true
-        },
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ==",
-          "dev": true
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-          "dev": true
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true
-        },
-        "prebuild-install": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-          "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-          "dev": true,
-          "requires": {
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
         "prr": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
           "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
         },
         "rimraf": {
           "version": "2.3.4",
@@ -2188,172 +1747,165 @@
             "glob": "4.5.3"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
           "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "simple-get": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-          "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "tar-fs": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-          "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-          "dev": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
-          }
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "dev": true,
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-          "dev": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
+    },
+    "leveldown": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
+      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
+      "requires": {
+        "abstract-leveldown": "2.6.3",
+        "bindings": "1.2.1",
+        "fast-future": "1.0.2",
+        "nan": "2.6.2",
+        "prebuild-install": "2.3.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "nan": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+        }
+      }
+    },
+    "levelup": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+      "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+      "requires": {
+        "bl": "0.8.2",
+        "deferred-leveldown": "0.2.0",
+        "errno": "0.1.4",
+        "prr": "0.0.0",
+        "readable-stream": "1.0.34",
+        "semver": "5.1.1",
+        "xtend": "3.0.0"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
+    "libsodium": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
+      "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
+    },
+    "libsodium-wrappers": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
+      "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
+      "requires": {
+        "libsodium": "0.2.12"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
+    "longest-streak": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
+    },
+    "looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+    },
+    "map-filter-reduce": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
+      "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
+      "requires": {
+        "binary-search": "1.3.2",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "3.6.1",
+        "typewiselite": "1.0.0"
+      }
+    },
+    "map-merge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
+      "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "markdown-table": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
     },
     "mdmanifest": {
       "version": "1.0.8",
@@ -2364,1075 +1916,6 @@
         "remark": "3.2.3",
         "remark-html": "2.0.2",
         "word-wrap": "1.2.3"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "anymatch": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-          "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
-          }
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "requires": {
-            "array-uniq": "1.0.3"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        },
-        "async-each": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-          "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-        },
-        "attach-ware": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
-          "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
-          "requires": {
-            "unherit": "1.1.0"
-          }
-        },
-        "bail": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
-          "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "binary-extensions": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-          "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "ccount": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
-          "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "character-entities": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
-          "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
-        },
-        "character-entities-html4": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
-          "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
-        },
-        "character-entities-legacy": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
-          "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
-        },
-        "character-reference-invalid": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
-          "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
-        },
-        "chokidar": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-          "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "co": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "collapse-white-space": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
-          "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "detab": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
-          "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
-          "requires": {
-            "repeat-string": "1.6.1"
-          }
-        },
-        "elegant-spinner": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-          "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-          "requires": {
-            "fill-range": "2.2.3"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "extend.js": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz",
-          "integrity": "sha1-D5x6gaHyCLcD6wwxMf5XFqxuzRU="
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "2.0.1"
-          }
-        },
-        "globby": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-          "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "6.0.4",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "he": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-          "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "irregular-plurals": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-          "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA=="
-        },
-        "is-alphabetical": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
-          "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
-        },
-        "is-alphanumerical": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
-          "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
-          "requires": {
-            "is-alphabetical": "1.0.1",
-            "is-decimal": "1.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-          "requires": {
-            "binary-extensions": "1.10.0"
-          }
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
-        },
-        "is-decimal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
-          "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-hexadecimal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
-          "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "requires": {
-            "chalk": "1.1.3"
-          }
-        },
-        "log-update": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-          "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "cli-cursor": "1.0.2"
-          }
-        },
-        "longest-streak": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
-          "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
-        },
-        "markdown-table": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
-          "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
-        "normalize-uri": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.0.tgz",
-          "integrity": "sha1-AftEDH/QWbnZvoZFqsFDQe/QWd0="
-        },
-        "npm-prefix": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
-          "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
-          "requires": {
-            "rc": "1.2.1",
-            "shellsubstitute": "1.2.0",
-            "untildify": "2.1.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "parse-entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-          "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
-          "requires": {
-            "character-entities": "1.2.1",
-            "character-entities-legacy": "1.1.1",
-            "character-reference-invalid": "1.1.1",
-            "is-alphanumerical": "1.0.1",
-            "is-decimal": "1.0.1",
-            "is-hexadecimal": "1.0.1"
-          }
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "plur": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-          "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-          "requires": {
-            "irregular-plurals": "1.3.0"
-          }
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readdirp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-          "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "readable-stream": "2.3.3",
-            "set-immediate-shim": "1.0.1"
-          }
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
-        "remark": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
-          "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
-          "requires": {
-            "camelcase": "2.1.1",
-            "ccount": "1.0.2",
-            "chalk": "1.1.3",
-            "chokidar": "1.7.0",
-            "collapse-white-space": "1.0.3",
-            "commander": "2.11.0",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.8",
-            "elegant-spinner": "1.0.1",
-            "extend.js": "0.0.2",
-            "glob": "6.0.4",
-            "globby": "4.1.0",
-            "he": "0.5.0",
-            "log-update": "1.0.2",
-            "longest-streak": "1.0.0",
-            "markdown-table": "0.4.0",
-            "minimatch": "3.0.4",
-            "npm-prefix": "1.2.0",
-            "parse-entities": "1.1.1",
-            "repeat-string": "1.6.1",
-            "stringify-entities": "1.3.1",
-            "to-vfile": "1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "1.1.0",
-            "unified": "2.1.4",
-            "user-home": "2.0.0",
-            "vfile": "1.4.0",
-            "vfile-find-down": "1.0.0",
-            "vfile-find-up": "1.0.0",
-            "vfile-reporter": "1.5.0",
-            "ware": "1.3.0"
-          }
-        },
-        "remark-html": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
-          "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
-          "requires": {
-            "collapse-white-space": "1.0.3",
-            "detab": "1.0.2",
-            "normalize-uri": "1.1.0",
-            "object-assign": "4.1.1",
-            "trim": "0.0.1",
-            "trim-lines": "1.1.0",
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "set-immediate-shim": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-          "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-        },
-        "shellsubstitute": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
-          "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringify-entities": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
-          "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
-          "requires": {
-            "character-entities-html4": "1.1.1",
-            "character-entities-legacy": "1.1.1",
-            "is-alphanumerical": "1.0.1",
-            "is-hexadecimal": "1.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-        },
-        "to-vfile": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
-          "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
-          "requires": {
-            "vfile": "1.4.0"
-          }
-        },
-        "trim": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-        },
-        "trim-lines": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.0.tgz",
-          "integrity": "sha1-mSbQPt4Tuhj31CIiYx+wTHn/Jv4="
-        },
-        "trim-trailing-lines": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-          "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "unherit": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-          "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "unified": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
-          "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
-          "requires": {
-            "attach-ware": "1.1.1",
-            "bail": "1.0.2",
-            "extend": "3.0.1",
-            "unherit": "1.1.0",
-            "vfile": "1.4.0",
-            "ware": "1.3.0"
-          }
-        },
-        "unist-util-visit": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.3.tgz",
-          "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs="
-        },
-        "untildify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "vfile": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
-          "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
-        },
-        "vfile-find-down": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
-          "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
-          "requires": {
-            "to-vfile": "1.0.0"
-          }
-        },
-        "vfile-find-up": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
-          "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
-          "requires": {
-            "to-vfile": "1.0.0"
-          }
-        },
-        "vfile-reporter": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
-          "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
-          "requires": {
-            "chalk": "1.1.3",
-            "log-symbols": "1.0.2",
-            "plur": "2.1.2",
-            "repeat-string": "1.6.1",
-            "string-width": "1.0.2",
-            "text-table": "0.2.0",
-            "vfile-sort": "1.0.0"
-          }
-        },
-        "vfile-sort": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz",
-          "integrity": "sha1-F+5JG6Q+iVG7IpE/z/MqfcTSNNQ="
-        },
-        "ware": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
-          "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-          "requires": {
-            "wrap-fn": "0.1.5"
-          }
-        },
-        "word-wrap": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-        },
-        "wrap-fn": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
-          "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-          "requires": {
-            "co": "3.1.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
       }
     },
     "memdown": {
@@ -3441,39 +1924,73 @@
       "integrity": "sha1-09H+m9YMObXhViR4kOpflfp2Trk=",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "2.7.0",
+        "abstract-leveldown": "2.7.2",
         "functional-red-black-tree": "1.0.1",
         "inherits": "2.0.3",
         "ltgt": "1.0.2"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.0.tgz",
-          "integrity": "sha512-maam3ZrTeORbXKEJUeJZkYOsorEwr060WitXuQlUuIFlg0RofyyHts49wtaVmShJ6l0wEWB0ZtPhf6QYBA7D2w==",
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "dev": true,
           "requires": {
             "xtend": "4.0.1"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
         },
         "ltgt": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-1.0.2.tgz",
           "integrity": "sha1-5oF+sprSBPwMnpbviw/umO9rmqM=",
           "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -3495,6 +2012,16 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "monotonic-timestamp": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
+      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiblob": {
       "version": "1.12.0",
@@ -3518,30 +2045,15 @@
         "rimraf": "2.2.8"
       },
       "dependencies": {
-        "blake2s": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.0.1.tgz",
-          "integrity": "sha1-FZiCKjIOzmqkAbqYKVT4L2GwzXs="
-        },
         "deep-extend": {
           "version": "0.2.11",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
           "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
         },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "pull-defer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
-          "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
         },
         "pull-file": {
           "version": "0.5.0",
@@ -3549,35 +2061,6 @@
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "requires": {
             "pull-utf8-decoder": "1.0.2"
-          }
-        },
-        "pull-fs": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
-          "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
-          "requires": {
-            "pull-file": "0.5.0",
-            "pull-stream": "3.6.1",
-            "pull-traverse": "1.0.3",
-            "pull-write-file": "0.2.4"
-          }
-        },
-        "pull-glob": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.6.tgz",
-          "integrity": "sha1-3qWsWUjuFZeNqyTXdyApJ/aK6KY=",
-          "requires": {
-            "pull-fs": "1.1.6",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-live": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
           }
         },
         "pull-notify": {
@@ -3588,28 +2071,13 @@
             "pull-pushable": "2.1.1"
           }
         },
-        "pull-traverse": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-          "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
-        },
-        "pull-utf8-decoder": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-          "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
-        },
-        "pull-write-file": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
-          "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
-        },
         "rc": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
           "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
           "requires": {
             "deep-extend": "0.2.11",
-            "ini": "1.3.4",
+            "ini": "1.3.5",
             "minimist": "0.0.10",
             "strip-json-comments": "0.1.3"
           }
@@ -3626,10 +2094,33 @@
         }
       }
     },
+    "multiblob-http": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.2.1.tgz",
+      "integrity": "sha1-N8C+qsxx0YNgEsBi282teX0CIps=",
+      "requires": {
+        "pull-stream": "3.6.1",
+        "stream-to-pull-stream": "1.7.2"
+      }
+    },
     "multicb": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
       "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+    },
+    "multiserver": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
+      "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
+      "requires": {
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.1",
+        "pull-ws": "3.3.0",
+        "secret-handshake": "1.1.11",
+        "separator-escape": "0.0.0",
+        "socks": "1.1.9",
+        "stream-to-pull-stream": "1.7.2"
+      }
     },
     "muxrpc": {
       "version": "6.3.3",
@@ -3641,55 +2132,6 @@
         "packet-stream-codec": "1.1.2",
         "pull-goodbye": "0.0.2",
         "pull-stream": "3.6.1"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-        },
-        "packet-stream": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.2.tgz",
-          "integrity": "sha1-uQt/m6tKliQiy8nLJHGcNT5JMmc="
-        },
-        "packet-stream-codec": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
-          "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
-          "requires": {
-            "pull-reader": "1.2.9",
-            "pull-through": "1.0.18"
-          }
-        },
-        "pull-goodbye": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
-          "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
-          "requires": {
-            "pull-stream": "3.5.0"
-          },
-          "dependencies": {
-            "pull-stream": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
-              "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
-            }
-          }
-        },
-        "pull-reader": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-          "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
-        },
-        "pull-through": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-          "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-          "requires": {
-            "looper": "3.0.0"
-          }
-        }
       }
     },
     "muxrpc-validation": {
@@ -3701,11 +2143,6 @@
         "zerr": "1.0.4"
       },
       "dependencies": {
-        "pull-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-          "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
-        },
         "pull-stream": {
           "version": "2.28.4",
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
@@ -3727,11 +2164,6 @@
         "word-wrap": "1.2.3"
       },
       "dependencies": {
-        "pull-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-          "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
-        },
         "pull-stream": {
           "version": "2.28.4",
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
@@ -3739,11 +2171,6 @@
           "requires": {
             "pull-core": "1.1.0"
           }
-        },
-        "word-wrap": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         }
       }
     },
@@ -3757,77 +2184,6 @@
         "rimraf": "2.4.5"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "ncp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-          "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
         "rimraf": {
           "version": "2.4.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
@@ -3835,13 +2191,38 @@
           "requires": {
             "glob": "6.0.4"
           }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+    },
+    "node-abi": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+      "requires": {
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
+      }
+    },
+    "node-gyp-build": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
+      "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ=="
     },
     "non-private-ip": {
       "version": "1.1.0",
@@ -3850,6 +2231,67 @@
       "requires": {
         "ip": "0.3.3"
       }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.1.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-uri": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.0.tgz",
+      "integrity": "sha1-AftEDH/QWbnZvoZFqsFDQe/QWd0="
+    },
+    "npm-prefix": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
+      "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
+      "requires": {
+        "rc": "1.2.2",
+        "shellsubstitute": "1.2.0",
+        "untildify": "2.1.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "0.3.1",
@@ -3863,19 +2305,26 @@
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "observ": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
+      "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
+    },
     "observ-debounce": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
       "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
       "requires": {
         "observ": "0.2.0"
-      },
-      "dependencies": {
-        "observ": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
-          "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
-        }
       }
     },
     "obv": {
@@ -3893,6 +2342,29 @@
       "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
       "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3905,24 +2377,202 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
-      },
-      "dependencies": {
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        }
       }
+    },
+    "packet-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.2.tgz",
+      "integrity": "sha1-uQt/m6tKliQiy8nLJHGcNT5JMmc="
+    },
+    "packet-stream-codec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
+      "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
+      "requires": {
+        "pull-reader": "1.2.9",
+        "pull-through": "1.0.18"
+      }
+    },
+    "parse-entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "requires": {
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
+    },
+    "prebuild-install": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
+      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
+      "requires": {
+        "expand-template": "1.1.0",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.1.2",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "1.0.3",
+        "rc": "1.2.2",
+        "simple-get": "1.4.3",
+        "tar-fs": "1.16.0",
+        "tunnel-agent": "0.6.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "private-box": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
+      "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
+      "requires": {
+        "chloride": "2.2.8"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pull-abortable": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
       "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
     },
+    "pull-box-stream": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
+      "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
+      "requires": {
+        "chloride": "2.2.8",
+        "increment-buffer": "1.0.1",
+        "pull-reader": "1.2.9",
+        "pull-stream": "3.6.1",
+        "pull-through": "1.0.18",
+        "split-buffer": "1.0.0"
+      }
+    },
     "pull-cat": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
       "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+    },
+    "pull-cont": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
+      "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
+    },
+    "pull-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
+      "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+    },
+    "pull-cursor": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-2.1.3.tgz",
+      "integrity": "sha1-Ah6X19I9eK9mrda4wcF/1v2xK2w=",
+      "requires": {
+        "looper": "4.0.0",
+        "ltgt": "2.2.0",
+        "pull-stream": "3.6.1"
+      }
+    },
+    "pull-defer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+      "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
     },
     "pull-file": {
       "version": "1.0.0",
@@ -3930,19 +2580,68 @@
       "integrity": "sha1-WgywNteO4Q4+C0KT389u/6EDYxg=",
       "requires": {
         "pull-utf8-decoder": "1.0.2"
-      },
-      "dependencies": {
-        "pull-utf8-decoder": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-          "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
-        }
       }
     },
     "pull-flatmap": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
       "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
+    },
+    "pull-fs": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
+      "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
+      "requires": {
+        "pull-file": "0.5.0",
+        "pull-stream": "3.6.1",
+        "pull-traverse": "1.0.3",
+        "pull-write-file": "0.2.4"
+      },
+      "dependencies": {
+        "pull-file": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
+          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
+          "requires": {
+            "pull-utf8-decoder": "1.0.2"
+          }
+        }
+      }
+    },
+    "pull-glob": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.6.tgz",
+      "integrity": "sha1-3qWsWUjuFZeNqyTXdyApJ/aK6KY=",
+      "requires": {
+        "pull-fs": "1.1.6",
+        "pull-stream": "3.6.1"
+      }
+    },
+    "pull-goodbye": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
+      "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
+      "requires": {
+        "pull-stream": "3.5.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
+          "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
+        }
+      }
+    },
+    "pull-handshake": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
+      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
+      "requires": {
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-pushable": "2.1.1",
+        "pull-reader": "1.2.9"
+      }
     },
     "pull-hash": {
       "version": "1.0.0",
@@ -3977,43 +2676,23 @@
         "pull-stream": "3.6.1",
         "pull-window": "2.1.4",
         "stream-to-pull-stream": "1.7.2"
-      },
-      "dependencies": {
-        "level-post": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-          "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
-          "requires": {
-            "ltgt": "2.2.0"
-          }
-        },
-        "looper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
-        },
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-        },
-        "pull-live": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-window": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-          "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
-          "requires": {
-            "looper": "2.0.0"
-          }
-        }
+      }
+    },
+    "pull-live": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+      "requires": {
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.1"
+      }
+    },
+    "pull-looper": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
+      "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
+      "requires": {
+        "looper": "4.0.0"
       }
     },
     "pull-many": {
@@ -4037,19 +2716,17 @@
         "pull-pushable": "2.1.1"
       }
     },
+    "pull-pair": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
+      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
+    },
     "pull-paramap": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
         "looper": "4.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        }
       }
     },
     "pull-ping": {
@@ -4067,6 +2744,24 @@
       "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
       "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg="
     },
+    "pull-rate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
+      "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
+      "requires": {
+        "pull-stream": "3.6.1"
+      }
+    },
+    "pull-reader": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
+      "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
+    },
+    "pull-sink-through": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
+      "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+    },
     "pull-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
@@ -4082,6 +2777,317 @@
       "resolved": "https://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz",
       "integrity": "sha1-Whw04Adfry8vbUYATjbczTO9fHw="
     },
+    "pull-through": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
+      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
+      "requires": {
+        "looper": "3.0.0"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        }
+      }
+    },
+    "pull-traverse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
+      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
+    },
+    "pull-utf8-decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
+      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
+    },
+    "pull-window": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+      "requires": {
+        "looper": "2.0.0"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
+        }
+      }
+    },
+    "pull-write": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
+      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
+      "requires": {
+        "looper": "4.0.0",
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.1"
+      }
+    },
+    "pull-write-file": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
+      "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
+    },
+    "pull-ws": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.0.tgz",
+      "integrity": "sha1-4cQ+9AMyFn3YEg71nt9+iSvqSq4=",
+      "requires": {
+        "relative-url": "1.0.2",
+        "safe-buffer": "5.1.1",
+        "ws": "1.1.5"
+      }
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      }
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "relative-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
+      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+    },
+    "remark": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
+      "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "ccount": "1.0.2",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "collapse-white-space": "1.0.3",
+        "commander": "2.11.0",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "elegant-spinner": "1.0.1",
+        "extend.js": "0.0.2",
+        "glob": "6.0.4",
+        "globby": "4.1.0",
+        "he": "0.5.0",
+        "log-update": "1.0.2",
+        "longest-streak": "1.0.0",
+        "markdown-table": "0.4.0",
+        "minimatch": "3.0.4",
+        "npm-prefix": "1.2.0",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "stringify-entities": "1.3.1",
+        "to-vfile": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unified": "2.1.4",
+        "user-home": "2.0.0",
+        "vfile": "1.4.0",
+        "vfile-find-down": "1.0.0",
+        "vfile-find-up": "1.0.0",
+        "vfile-reporter": "1.5.0",
+        "ware": "1.3.0"
+      }
+    },
+    "remark-html": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
+      "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "detab": "1.0.2",
+        "normalize-uri": "1.1.0",
+        "object-assign": "4.1.1",
+        "trim": "0.0.1",
+        "trim-lines": "1.1.0",
+        "unist-util-visit": "1.2.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -4090,30 +3096,6 @@
         "glob": "7.1.2"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -4126,47 +3108,24 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "secret-handshake": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.11.tgz",
+      "integrity": "sha1-I51hNnjx5cUPIj8mBfNkdc79Zl4=",
+      "requires": {
+        "chloride": "2.2.8",
+        "deep-equal": "1.0.1",
+        "pull-box-stream": "1.0.13",
+        "pull-handshake": "1.1.4",
+        "pull-stream": "3.6.1"
       }
     },
     "secret-stack": {
@@ -4186,112 +3145,10 @@
         "stream-to-pull-stream": "1.7.2"
       },
       "dependencies": {
-        "chloride": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.7.tgz",
-          "integrity": "sha1-DmqdEYlKvkpEkR05iNoZLiIIt4Y=",
-          "requires": {
-            "is-electron": "2.1.0",
-            "sodium-browserify": "1.2.1",
-            "sodium-browserify-tweetnacl": "0.2.3",
-            "sodium-chloride": "1.1.0",
-            "sodium-native": "1.10.3"
-          }
-        },
-        "chloride-test": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
-          "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
-          "requires": {
-            "json-buffer": "2.0.11"
-          }
-        },
-        "ed2curve": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
-          "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "hoox": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
-          "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
-        },
-        "increment-buffer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
-          "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "ip": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "is-electron": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
-          "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
-        },
-        "json-buffer": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
-          "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
-        },
-        "libsodium": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-          "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
-        },
-        "libsodium-wrappers": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-          "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
-          "requires": {
-            "libsodium": "0.2.12"
-          }
-        },
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-        },
-        "map-merge": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
-          "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
-        },
-        "multiserver": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
-          "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1",
-            "pull-ws": "3.2.10",
-            "secret-handshake": "1.1.11",
-            "separator-escape": "0.0.0",
-            "socks": "1.1.9",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "optional": true
-        },
-        "node-gyp-build": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-          "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
-          "optional": true
         },
         "non-private-ip": {
           "version": "1.4.2",
@@ -4307,607 +3164,53 @@
               "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
             }
           }
-        },
-        "options": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-        },
-        "pull-box-stream": {
-          "version": "1.0.13",
-          "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
-          "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
-          "requires": {
-            "chloride": "2.2.7",
-            "increment-buffer": "1.0.1",
-            "pull-reader": "1.2.9",
-            "pull-stream": "3.6.1",
-            "pull-through": "1.0.18",
-            "split-buffer": "1.0.0"
-          }
-        },
-        "pull-handshake": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-          "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-pair": "1.1.0",
-            "pull-pushable": "2.1.1",
-            "pull-reader": "1.2.9"
-          }
-        },
-        "pull-pair": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-          "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-        },
-        "pull-rate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
-          "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
-          "requires": {
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-reader": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-          "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
-        },
-        "pull-through": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-          "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-          "requires": {
-            "looper": "3.0.0"
-          }
-        },
-        "pull-ws": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.2.10.tgz",
-          "integrity": "sha1-9yUsh/diqCdt18cR5zu8+T26xUk=",
-          "requires": {
-            "relative-url": "1.0.2",
-            "safe-buffer": "5.1.1",
-            "ws": "1.1.4"
-          }
-        },
-        "relative-url": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-          "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "secret-handshake": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.11.tgz",
-          "integrity": "sha1-I51hNnjx5cUPIj8mBfNkdc79Zl4=",
-          "requires": {
-            "chloride": "2.2.7",
-            "deep-equal": "1.0.1",
-            "pull-box-stream": "1.0.13",
-            "pull-handshake": "1.1.4",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "separator-escape": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
-          "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
-        },
-        "sha.js": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
-          "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "smart-buffer": {
-          "version": "1.1.15",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-        },
-        "socks": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
-          "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
-          "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
-          }
-        },
-        "sodium-browserify": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-          "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
-          "requires": {
-            "libsodium-wrappers": "0.2.12",
-            "sha.js": "2.4.5",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "sodium-browserify-tweetnacl": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
-          "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
-          "requires": {
-            "chloride-test": "1.2.2",
-            "ed2curve": "0.1.4",
-            "sha.js": "2.4.8",
-            "tweetnacl": "0.14.5",
-            "tweetnacl-auth": "0.3.1"
-          },
-          "dependencies": {
-            "sha.js": {
-              "version": "2.4.8",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-              "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            }
-          }
-        },
-        "sodium-chloride": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
-          "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
-        },
-        "sodium-native": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.3.tgz",
-          "integrity": "sha512-FIeYaG5cc0YZjsAaWP/BCXDNO2xusbtDJbCbEvXrf6/6+dRo/8XCiEG0kwlRcR0wr56sgsZ327BId3ifFe2WYw==",
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0",
-            "node-gyp-build": "3.2.2"
-          }
-        },
-        "split-buffer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
-          "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "tweetnacl-auth": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
-          "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "ultron": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-        },
-        "ws": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
-          "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-          "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
-          }
         }
       }
     },
     "secure-scuttlebutt": {
-      "version": "16.3.7",
-      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-16.3.7.tgz",
-      "integrity": "sha1-E81tgE3gf3ekgPDMLI5ScoB0GH0=",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-17.0.2.tgz",
+      "integrity": "sha1-I22KopzkrH7x7N3J0Bx8uExKypY=",
       "requires": {
-        "bytewise": "1.1.0",
+        "async-write": "2.1.0",
         "cont": "1.0.3",
         "deep-equal": "0.2.2",
         "explain-error": "1.0.4",
-        "flumedb": "0.3.1",
-        "flumelog-offset": "3.2.2",
-        "flumeview-level": "2.0.5",
-        "flumeview-reduce": "1.3.3",
+        "flumecodec": "0.0.1",
+        "flumedb": "0.4.2",
+        "flumelog-offset": "3.2.6",
+        "flumeview-hashtable": "1.0.3",
+        "flumeview-level": "2.1.0",
+        "flumeview-reduce": "1.3.9",
         "level": "1.7.0",
-        "level-codec": "6.2.0",
-        "level-peek": "2.0.2",
         "level-sublevel": "6.6.1",
         "ltgt": "2.2.0",
         "monotonic-timestamp": "0.0.9",
         "obv": "0.0.1",
-        "pull-cat": "1.1.11",
         "pull-cont": "0.0.0",
-        "pull-defer": "0.2.2",
         "pull-level": "2.0.3",
         "pull-live": "1.0.1",
         "pull-notify": "0.1.1",
         "pull-paramap": "1.2.2",
         "pull-stream": "3.6.1",
-        "pull-write": "1.1.4",
-        "ssb-feed": "2.3.0",
-        "ssb-keys": "7.0.10",
+        "ssb-keys": "7.0.13",
         "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.7.1",
+        "ssb-ref": "2.8.0",
+        "ssb-validate": "3.0.0",
         "typewiselite": "1.0.0"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "aligned-block-file": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.2.tgz",
-          "integrity": "sha1-SpFo1f7+Xi9SWUncVaSqCZA7MtQ=",
-          "requires": {
-            "hashlru": "2.2.0",
-            "int53": "0.2.4",
-            "mkdirp": "0.5.1",
-            "obv": "0.0.0",
-            "uint48be": "1.0.2"
-          },
-          "dependencies": {
-            "obv": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-              "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "append-batch": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
-          "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU="
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        },
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "bytewise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-          "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
-          }
-        },
-        "bytewise-core": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
         "deep-equal": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
           "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
         },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "requires": {
-            "prr": "0.0.0"
-          },
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-            }
-          }
-        },
-        "expand-template": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-          "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-        },
-        "fast-future": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-        },
-        "flumedb": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.3.1.tgz",
-          "integrity": "sha1-E0GmHanBgm9Rw5fv/WLw84QW9iE=",
-          "requires": {
-            "cont": "1.0.3",
-            "explain-error": "1.0.4",
-            "obv": "0.0.1",
-            "pull-cont": "0.0.0",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "flumelog-offset": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.2.2.tgz",
-          "integrity": "sha512-ZU51QP3KCNGiv4VoX4MhbMAB1izAdyUNKkBHp7WKiNk5F8ZOiXAJ2u+8qIYW4GUOAWU52KAm9Ugx6C6TPCUKMQ==",
-          "requires": {
-            "aligned-block-file": "1.1.2",
-            "append-batch": "0.0.1",
-            "explain-error": "1.0.4",
-            "hashlru": "2.2.0",
-            "int53": "0.2.4",
-            "looper": "4.0.0",
-            "ltgt": "2.2.0",
-            "obv": "0.0.1",
-            "pull-cursor": "2.1.3",
-            "uint48be": "1.0.2"
-          }
-        },
-        "flumeview-level": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-2.0.5.tgz",
-          "integrity": "sha512-WZSG7gVSw2MeCf0fXYTFOrKShSA+titEdfxnk63uVY+21Gxh0AezL6xkbH7ykDmOjhV8o8wyNQMFJKf4XvoVNw==",
-          "requires": {
-            "bytewise": "1.1.0",
-            "explain-error": "1.0.4",
-            "level": "1.7.0",
-            "ltgt": "2.2.0",
-            "mkdirp": "0.5.1",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.1",
-            "pull-write": "1.1.4"
-          },
-          "dependencies": {
-            "obv": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-              "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-            }
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "hashlru": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.0.tgz",
-          "integrity": "sha1-eTpYlD+QKupXgXfXsDNfE/JpS3E="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "int53": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
-          "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
+        "flumecodec": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-          "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
+          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+          "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
           "requires": {
-            "level-packager": "1.2.1",
-            "leveldown": "1.7.2"
-          }
-        },
-        "level-codec": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-          "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "requires": {
-            "levelup": "1.3.9"
-          }
-        },
-        "level-peek": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/level-peek/-/level-peek-2.0.2.tgz",
-          "integrity": "sha1-1M3bffYg96R61d2F4PkhM0UjogY=",
-          "requires": {
-            "pull-level": "2.0.3",
-            "pull-stream": "3.6.1"
+            "level-codec": "6.2.0"
           }
         },
         "level-sublevel": {
@@ -4924,470 +3227,60 @@
             "xtend": "4.0.1"
           },
           "dependencies": {
-            "abstract-leveldown": {
-              "version": "0.12.4",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-              "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-              "requires": {
-                "xtend": "3.0.0"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-                }
-              }
-            },
-            "bl": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-              "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-              "requires": {
-                "readable-stream": "1.0.34"
-              }
-            },
-            "deferred-leveldown": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-              "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-              "requires": {
-                "abstract-leveldown": "0.12.4"
-              }
-            },
-            "levelup": {
-              "version": "0.19.1",
-              "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-              "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-              "requires": {
-                "bl": "0.8.2",
-                "deferred-leveldown": "0.2.0",
-                "errno": "0.1.4",
-                "prr": "0.0.0",
-                "readable-stream": "1.0.34",
-                "semver": "5.1.1",
-                "xtend": "3.0.0"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-                }
-              }
-            },
             "ltgt": {
               "version": "2.1.3",
               "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
               "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-            },
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "semver": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-              "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
             }
           }
-        },
-        "leveldown": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-          "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-          "requires": {
-            "abstract-leveldown": "2.6.3",
-            "bindings": "1.2.1",
-            "fast-future": "1.0.2",
-            "nan": "2.6.2",
-            "prebuild-install": "2.2.2"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "level-codec": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-            }
-          }
-        },
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        },
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-        },
-        "monotonic-timestamp": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
-          "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        },
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "obv": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
-          "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "prebuild-install": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-          "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-          "requires": {
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "pull-cont": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
-          "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
-        },
-        "pull-cursor": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-2.1.3.tgz",
-          "integrity": "sha1-Ah6X19I9eK9mrda4wcF/1v2xK2w=",
-          "requires": {
-            "looper": "4.0.0",
-            "ltgt": "2.2.0",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-defer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
-          "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
-        },
-        "pull-live": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-write": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-          "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-          "requires": {
-            "looper": "4.0.0",
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-get": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-          "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-          "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
-          }
-        },
-        "ssb-feed": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/ssb-feed/-/ssb-feed-2.3.0.tgz",
-          "integrity": "sha1-uE6OApeg9ZBMTPWiAvdroeB40Ec=",
-          "requires": {
-            "cont": "1.0.3",
-            "monotonic-timestamp": "0.0.9",
-            "pull-stream": "3.6.1",
-            "ssb-keys": "7.0.10",
-            "ssb-ref": "2.7.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "tar-fs": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-          "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-          "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
-          }
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "typewise": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "typewise-core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
-        },
-        "typewiselite": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-        },
-        "uint48be": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz",
-          "integrity": "sha512-jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA=="
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
+    },
+    "semver": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+      "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
+    },
+    "separator-escape": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
+      "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "sha.js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+      "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shellsubstitute": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
+      "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -5395,10 +3288,119 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-get": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
+      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "requires": {
+        "once": "1.4.0",
+        "unzip-response": "1.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "smart-buffer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+    },
+    "socks": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
+      "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        }
+      }
+    },
+    "sodium-browserify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
+      "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
+      "requires": {
+        "libsodium-wrappers": "0.2.12",
+        "sha.js": "2.4.5",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "sodium-browserify-tweetnacl": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
+      "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
+      "requires": {
+        "chloride-test": "1.2.2",
+        "ed2curve": "0.1.4",
+        "sha.js": "2.4.9",
+        "tweetnacl": "0.14.5",
+        "tweetnacl-auth": "0.3.1"
+      },
+      "dependencies": {
+        "sha.js": {
+          "version": "2.4.9",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+          "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "sodium-chloride": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
+      "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
+    },
+    "sodium-native": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.0.1.tgz",
+      "integrity": "sha512-3xi2SbjeEUivlH4zPaBIaxQtpAInq4T3zX9kaeDquzgXRv96QLbTR0AcJeqXj3JeKdhwJ6YiLS3XFrnMp4tc+w==",
+      "requires": {
+        "nan": "2.8.0",
+        "node-gyp-build": "3.2.2"
+      }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "split-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
+      "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+    },
     "ssb-blobs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.3.tgz",
-      "integrity": "sha1-RCY91EixgvjjSL5rNSD9qSxwI7M=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.4.tgz",
+      "integrity": "sha1-2T8pYLSU4QZXhp/zu59y32lxXck=",
       "requires": {
         "cont": "1.0.3",
         "level": "1.7.0",
@@ -5406,386 +3408,9 @@
         "pull-level": "1.5.2",
         "pull-notify": "0.1.1",
         "pull-stream": "3.6.1",
-        "ssb-ref": "2.7.1"
+        "ssb-ref": "2.8.0"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        },
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "requires": {
-            "prr": "0.0.0"
-          },
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-            }
-          }
-        },
-        "expand-template": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-          "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-        },
-        "fast-future": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-          "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-          "requires": {
-            "level-packager": "1.2.1",
-            "leveldown": "1.7.2"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "requires": {
-            "levelup": "1.3.9"
-          }
-        },
-        "level-post": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-          "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
-          "requires": {
-            "ltgt": "2.2.0"
-          }
-        },
-        "leveldown": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-          "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-          "requires": {
-            "abstract-leveldown": "2.6.3",
-            "bindings": "1.2.1",
-            "fast-future": "1.0.2",
-            "nan": "2.6.2",
-            "prebuild-install": "2.2.2"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "looper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
-        },
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        },
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "prebuild-install": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-          "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-          "requires": {
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
         "pull-level": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-1.5.2.tgz",
@@ -5798,197 +3423,13 @@
             "pull-window": "2.1.4",
             "stream-to-pull-stream": "1.7.2"
           }
-        },
-        "pull-window": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-          "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
-          "requires": {
-            "looper": "2.0.0"
-          }
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-get": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-          "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-          "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "tar-fs": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-          "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-          "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
-          }
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "ssb-client": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.1.tgz",
-      "integrity": "sha512-Kn4eoSl3ZuS4BteQAtRIFM52jsGJPar4NJHLjis5OFxV22pNub/JfZHC2FdJBTtkPWJIJZi0ullCsm/EQ1Xs7Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.2.tgz",
+      "integrity": "sha1-aBnyPwrBz/O6MfOsr0NAzG6SwZ8=",
       "requires": {
         "explain-error": "1.0.4",
         "multicb": "1.2.2",
@@ -5997,291 +3438,7 @@
         "pull-hash": "1.0.0",
         "pull-stream": "3.6.1",
         "ssb-config": "2.2.0",
-        "ssb-keys": "7.0.10"
-      },
-      "dependencies": {
-        "chloride": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.7.tgz",
-          "integrity": "sha1-DmqdEYlKvkpEkR05iNoZLiIIt4Y=",
-          "requires": {
-            "is-electron": "2.1.0",
-            "sodium-browserify": "1.2.1",
-            "sodium-browserify-tweetnacl": "0.2.3",
-            "sodium-chloride": "1.1.0",
-            "sodium-native": "1.10.3"
-          }
-        },
-        "chloride-test": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
-          "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
-          "requires": {
-            "json-buffer": "2.0.11"
-          }
-        },
-        "ed2curve": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
-          "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "increment-buffer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
-          "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "is-electron": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
-          "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
-        },
-        "json-buffer": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
-          "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
-        },
-        "libsodium": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-          "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
-        },
-        "libsodium-wrappers": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-          "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
-          "requires": {
-            "libsodium": "0.2.12"
-          }
-        },
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-        },
-        "multiserver": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
-          "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1",
-            "pull-ws": "3.2.10",
-            "secret-handshake": "1.1.11",
-            "separator-escape": "0.0.0",
-            "socks": "1.1.9",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "optional": true
-        },
-        "node-gyp-build": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-          "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
-          "optional": true
-        },
-        "options": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-        },
-        "pull-box-stream": {
-          "version": "1.0.13",
-          "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
-          "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
-          "requires": {
-            "chloride": "2.2.7",
-            "increment-buffer": "1.0.1",
-            "pull-reader": "1.2.9",
-            "pull-stream": "3.6.1",
-            "pull-through": "1.0.18",
-            "split-buffer": "1.0.0"
-          }
-        },
-        "pull-handshake": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-          "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-pair": "1.1.0",
-            "pull-pushable": "2.1.1",
-            "pull-reader": "1.2.9"
-          }
-        },
-        "pull-pair": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-          "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-        },
-        "pull-reader": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-          "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
-        },
-        "pull-through": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-          "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-          "requires": {
-            "looper": "3.0.0"
-          }
-        },
-        "pull-ws": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.2.10.tgz",
-          "integrity": "sha1-9yUsh/diqCdt18cR5zu8+T26xUk=",
-          "requires": {
-            "relative-url": "1.0.2",
-            "safe-buffer": "5.1.1",
-            "ws": "1.1.4"
-          }
-        },
-        "relative-url": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-          "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "secret-handshake": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.11.tgz",
-          "integrity": "sha1-I51hNnjx5cUPIj8mBfNkdc79Zl4=",
-          "requires": {
-            "chloride": "2.2.7",
-            "deep-equal": "1.0.1",
-            "pull-box-stream": "1.0.13",
-            "pull-handshake": "1.1.4",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "separator-escape": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
-          "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
-        },
-        "sha.js": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
-          "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "smart-buffer": {
-          "version": "1.1.15",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-        },
-        "socks": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
-          "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
-          "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
-          }
-        },
-        "sodium-browserify": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-          "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
-          "requires": {
-            "libsodium-wrappers": "0.2.12",
-            "sha.js": "2.4.5",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "sodium-browserify-tweetnacl": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
-          "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
-          "requires": {
-            "chloride-test": "1.2.2",
-            "ed2curve": "0.1.4",
-            "sha.js": "2.4.8",
-            "tweetnacl": "0.14.5",
-            "tweetnacl-auth": "0.3.1"
-          },
-          "dependencies": {
-            "sha.js": {
-              "version": "2.4.8",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-              "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            }
-          }
-        },
-        "sodium-chloride": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
-          "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
-        },
-        "sodium-native": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.3.tgz",
-          "integrity": "sha512-FIeYaG5cc0YZjsAaWP/BCXDNO2xusbtDJbCbEvXrf6/6+dRo/8XCiEG0kwlRcR0wr56sgsZ327BId3ifFe2WYw==",
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0",
-            "node-gyp-build": "3.2.2"
-          }
-        },
-        "split-buffer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
-          "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "tweetnacl-auth": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
-          "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "ultron": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-        },
-        "ws": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
-          "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-          "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
-          }
-        }
+        "ssb-keys": "7.0.13"
       }
     },
     "ssb-config": {
@@ -6292,19 +3449,9 @@
         "deep-extend": "0.4.2",
         "non-private-ip": "1.4.2",
         "os-homedir": "1.0.2",
-        "rc": "1.2.1"
+        "rc": "1.2.2"
       },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
         "non-private-ip": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.2.tgz",
@@ -6312,49 +3459,23 @@
           "requires": {
             "ip": "0.3.3"
           }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
     "ssb-friends": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.2.3.tgz",
-      "integrity": "sha512-2SVderWO/xtF11uCPk00Zq+ZkXvb62ao077aTUuiXLroexW+H8qrXoumasrfODQbz9yZaMFol2T3KYPxLd3/mg==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.3.5.tgz",
+      "integrity": "sha1-thEfEU6LhyfmCOsVdTqu0aTAfl4=",
       "requires": {
-        "flumeview-reduce": "1.3.3",
+        "flumeview-reduce": "1.3.9",
         "graphreduce": "3.0.4",
         "obv": "0.0.1",
         "pull-cont": "0.1.1",
         "pull-flatmap": "0.0.1",
         "pull-stream": "3.6.1",
-        "ssb-ref": "2.7.1"
+        "ssb-ref": "2.8.0"
       },
       "dependencies": {
-        "obv": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
-          "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
-        },
         "pull-cont": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
@@ -6363,159 +3484,13 @@
       }
     },
     "ssb-keys": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.10.tgz",
-      "integrity": "sha1-VbelmRXy4CzzN7shnl/Uc2w15ho=",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.13.tgz",
+      "integrity": "sha1-nWUnEAWHawfOqie3JICPDGAQu8k=",
       "requires": {
-        "chloride": "2.2.7",
+        "chloride": "2.2.8",
         "mkdirp": "0.5.1",
         "private-box": "0.2.1"
-      },
-      "dependencies": {
-        "chloride": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.7.tgz",
-          "integrity": "sha1-DmqdEYlKvkpEkR05iNoZLiIIt4Y=",
-          "requires": {
-            "is-electron": "2.1.0",
-            "sodium-browserify": "1.2.1",
-            "sodium-browserify-tweetnacl": "0.2.3",
-            "sodium-chloride": "1.1.0",
-            "sodium-native": "1.10.3"
-          }
-        },
-        "chloride-test": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
-          "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
-          "requires": {
-            "json-buffer": "2.0.11"
-          }
-        },
-        "ed2curve": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
-          "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "is-electron": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
-          "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
-        },
-        "json-buffer": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
-          "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
-        },
-        "libsodium": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-          "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
-        },
-        "libsodium-wrappers": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-          "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
-          "requires": {
-            "libsodium": "0.2.12"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "optional": true
-        },
-        "node-gyp-build": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-          "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
-          "optional": true
-        },
-        "private-box": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
-          "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
-          "requires": {
-            "chloride": "2.2.7"
-          }
-        },
-        "sha.js": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
-          "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "sodium-browserify": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-          "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
-          "requires": {
-            "libsodium-wrappers": "0.2.12",
-            "sha.js": "2.4.5",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "sodium-browserify-tweetnacl": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
-          "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
-          "requires": {
-            "chloride-test": "1.2.2",
-            "ed2curve": "0.1.4",
-            "sha.js": "2.4.8",
-            "tweetnacl": "0.14.5",
-            "tweetnacl-auth": "0.3.1"
-          },
-          "dependencies": {
-            "sha.js": {
-              "version": "2.4.8",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-              "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            }
-          }
-        },
-        "sodium-chloride": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
-          "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
-        },
-        "sodium-native": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.3.tgz",
-          "integrity": "sha512-FIeYaG5cc0YZjsAaWP/BCXDNO2xusbtDJbCbEvXrf6/6+dRo/8XCiEG0kwlRcR0wr56sgsZ327BId3ifFe2WYw==",
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0",
-            "node-gyp-build": "3.2.2"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "tweetnacl-auth": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
-          "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        }
       }
     },
     "ssb-links": {
@@ -6523,670 +3498,10 @@
       "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.0.tgz",
       "integrity": "sha1-dXr7Pro2FGPo1MtFKZHCr46lwho=",
       "requires": {
-        "flumeview-query": "3.0.4",
+        "flumeview-query": "3.0.7",
         "map-filter-reduce": "2.2.1",
         "pull-stream": "3.6.1",
         "ssb-msgs": "5.2.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "binary-search": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz",
-          "integrity": "sha1-iMm3vStyIdNS2njsiH9a8lSeTeI="
-        },
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        },
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "bytewise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-          "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
-          }
-        },
-        "bytewise-core": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "requires": {
-            "prr": "0.0.0"
-          },
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-            }
-          }
-        },
-        "expand-template": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-          "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-        },
-        "fast-future": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-        },
-        "flumeview-level": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-1.0.3.tgz",
-          "integrity": "sha1-UzPKTH2y1lpePd1MHqiuWWSbmlM=",
-          "requires": {
-            "bytewise": "1.1.0",
-            "level": "1.7.0",
-            "ltgt": "2.2.0",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.1",
-            "pull-write": "1.1.4"
-          }
-        },
-        "flumeview-query": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-3.0.4.tgz",
-          "integrity": "sha1-qoClw3iOwpc3ptqHLL1w5kldIdE=",
-          "requires": {
-            "explain-error": "1.0.4",
-            "flumeview-level": "1.0.3",
-            "map-filter-reduce": "3.0.3",
-            "pull-flatmap": "0.0.1",
-            "pull-paramap": "1.2.2",
-            "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.1"
-          },
-          "dependencies": {
-            "map-filter-reduce": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.0.3.tgz",
-              "integrity": "sha1-ihC4bjRlut13YBqZV9velLmNYKo=",
-              "requires": {
-                "binary-search": "1.3.2",
-                "pull-sink-through": "0.0.0",
-                "pull-stream": "3.6.1",
-                "typewiselite": "1.0.0"
-              }
-            }
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-          "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-          "requires": {
-            "level-packager": "1.2.1",
-            "leveldown": "1.7.2"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "requires": {
-            "levelup": "1.3.9"
-          }
-        },
-        "leveldown": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-          "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-          "requires": {
-            "abstract-leveldown": "2.6.3",
-            "bindings": "1.2.1",
-            "fast-future": "1.0.2",
-            "nan": "2.6.2",
-            "prebuild-install": "2.2.2"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        },
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-        },
-        "map-filter-reduce": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
-          "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
-          "requires": {
-            "binary-search": "1.3.2",
-            "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.1",
-            "typewiselite": "1.0.0"
-          }
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        },
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "prebuild-install": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-          "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-          "requires": {
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "pull-sink-through": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
-          "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
-        },
-        "pull-write": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-          "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-          "requires": {
-            "looper": "4.0.0",
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-get": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-          "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-          "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "tar-fs": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-          "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-          "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
-          }
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "typewise": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "typewise-core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
-        },
-        "typewiselite": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
       }
     },
     "ssb-msg-schemas": {
@@ -7200,12 +3515,6 @@
         "ssb-ref": "0.0.0"
       },
       "dependencies": {
-        "pull-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-          "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo=",
-          "dev": true
-        },
         "pull-stream": {
           "version": "2.27.0",
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.27.0.tgz",
@@ -7237,359 +3546,33 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "2.7.1"
+        "ssb-ref": "2.8.0"
       }
     },
     "ssb-query": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-1.0.0.tgz",
-      "integrity": "sha1-MUAi6nKRC3XlrrndUQ5pYzSTBcU=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-1.0.1.tgz",
+      "integrity": "sha1-SAqq+RQFe8EsYYzjiuJ4kJMh+QI=",
       "requires": {
         "explain-error": "1.0.4",
-        "flumeview-query": "3.0.4",
+        "flumeview-query": "4.0.1",
         "pull-stream": "3.6.1",
         "streamview-links": "2.1.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "aproba": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "binary-search": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz",
-          "integrity": "sha1-iMm3vStyIdNS2njsiH9a8lSeTeI="
-        },
-        "bindings": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-        },
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "bytewise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-          "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
-          }
-        },
-        "bytewise-core": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-          "requires": {
-            "prr": "0.0.0"
-          },
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-            }
-          }
-        },
-        "expand-template": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-          "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-        },
-        "fast-future": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-        },
-        "flumeview-level": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-1.0.3.tgz",
-          "integrity": "sha1-UzPKTH2y1lpePd1MHqiuWWSbmlM=",
-          "requires": {
-            "bytewise": "1.1.0",
-            "level": "1.7.0",
-            "ltgt": "2.2.0",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.1",
-            "pull-write": "1.1.4"
-          }
-        },
         "flumeview-query": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-3.0.4.tgz",
-          "integrity": "sha1-qoClw3iOwpc3ptqHLL1w5kldIdE=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-4.0.1.tgz",
+          "integrity": "sha1-HNTf2S8acBKN2dgN3qqdRJVuzO0=",
           "requires": {
             "explain-error": "1.0.4",
-            "flumeview-level": "1.0.3",
+            "flumeview-level": "2.1.0",
             "map-filter-reduce": "3.0.3",
             "pull-flatmap": "0.0.1",
             "pull-paramap": "1.2.2",
             "pull-sink-through": "0.0.0",
             "pull-stream": "3.6.1"
           }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "github-from-package": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-          "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-          "requires": {
-            "level-packager": "1.2.1",
-            "leveldown": "1.7.2"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "requires": {
-            "levelup": "1.3.9"
-          }
-        },
-        "leveldown": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-          "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-          "requires": {
-            "abstract-leveldown": "2.6.3",
-            "bindings": "1.2.1",
-            "fast-future": "1.0.2",
-            "nan": "2.6.2",
-            "prebuild-install": "2.2.2"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        },
-        "ltgt": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-          "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
         },
         "map-filter-reduce": {
           "version": "3.0.3",
@@ -7601,349 +3584,39 @@
             "pull-stream": "3.6.1",
             "typewiselite": "1.0.0"
           }
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        },
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
-        },
-        "noop-logger": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "prebuild-install": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
-          "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
-          "requires": {
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.1.1",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "1.0.2",
-            "rc": "1.2.1",
-            "simple-get": "1.4.3",
-            "tar-fs": "1.15.3",
-            "tunnel-agent": "0.6.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "pull-live": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pull-sink-through": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
-          "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
-        },
-        "pull-write": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-          "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-          "requires": {
-            "looper": "4.0.0",
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "pump": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-          "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-get": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-          "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-          "requires": {
-            "once": "1.4.0",
-            "unzip-response": "1.0.2",
-            "xtend": "4.0.1"
-          }
-        },
-        "streamview-links": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/streamview-links/-/streamview-links-2.1.1.tgz",
-          "integrity": "sha1-2bdaw7NaJfzn7ZME3JgR07o4P/E=",
-          "requires": {
-            "bytewise": "1.1.0",
-            "explain-error": "1.0.4",
-            "level": "1.7.0",
-            "ltgt": "2.2.0",
-            "map-filter-reduce": "3.0.3",
-            "pull-level": "2.0.3",
-            "pull-live": "1.0.1",
-            "pull-paramap": "1.2.2",
-            "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.1",
-            "pull-write": "1.1.4"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "tar-fs": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-          "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-          "requires": {
-            "chownr": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pump": "1.0.2",
-            "tar-stream": "1.5.4"
-          }
-        },
-        "tar-stream": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-          "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-          "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "typewise": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-          "requires": {
-            "typewise-core": "1.2.0"
-          }
-        },
-        "typewise-core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
-        },
-        "typewiselite": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "ssb-ref": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.7.1.tgz",
-      "integrity": "sha1-XU7/xUXsD/1/wVuieCmmQLiir7o=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.8.0.tgz",
+      "integrity": "sha1-d8+c6oaROlu3kW4ma7ceavQdb24=",
       "requires": {
         "ip": "1.1.5",
-        "is-valid-domain": "0.0.2"
+        "is-valid-domain": "0.0.5"
       },
       "dependencies": {
         "ip": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "is-valid-domain": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.2.tgz",
-          "integrity": "sha1-PnqUI/98Oy/hFmOvvW04N6JR+3c="
         }
+      }
+    },
+    "ssb-sort": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-0.0.0.tgz",
+      "integrity": "sha1-OEwus/pIzEbF8R1Za/aGYZ+ol58=",
+      "requires": {
+        "ssb-ref": "2.8.0"
+      }
+    },
+    "ssb-validate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.0.tgz",
+      "integrity": "sha1-jDsLdhGabaQ4TMB78NMiYxAUuUU=",
+      "requires": {
+        "ssb-ref": "2.8.0"
       }
     },
     "ssb-ws": {
@@ -7952,414 +3625,20 @@
       "integrity": "sha1-+68EZOCWaPS7lRbSxBzcA6nWgdw=",
       "requires": {
         "emoji-server": "1.0.0",
-        "multiblob-http": "0.2.0",
+        "multiblob-http": "0.2.1",
         "multiserver": "1.10.0",
         "muxrpc": "6.3.3",
         "pull-stream": "3.6.1",
-        "ssb-ref": "2.7.1",
+        "ssb-ref": "2.8.0",
         "ssb-sort": "0.0.0",
         "stack": "0.1.0",
         "web-bootloader": "0.1.2"
-      },
-      "dependencies": {
-        "arraybuffer-base64": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/arraybuffer-base64/-/arraybuffer-base64-1.0.0.tgz",
-          "integrity": "sha1-/QIXuiuo1IYzZj+kOoCTdoAp2jA="
-        },
-        "binary-xhr": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/binary-xhr/-/binary-xhr-0.0.2.tgz",
-          "integrity": "sha1-IQywda0XeqRIpu+iiMEKiZw7OYc=",
-          "requires": {
-            "inherits": "1.0.0"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-              "integrity": "sha1-OOGXUoW/H3upyE2hArsSdxMirEg="
-            }
-          }
-        },
-        "browser-split": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-          "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
-        },
-        "chloride": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.7.tgz",
-          "integrity": "sha1-DmqdEYlKvkpEkR05iNoZLiIIt4Y=",
-          "requires": {
-            "is-electron": "2.1.0",
-            "sodium-browserify": "1.2.1",
-            "sodium-browserify-tweetnacl": "0.2.3",
-            "sodium-chloride": "1.1.0",
-            "sodium-native": "1.10.3"
-          }
-        },
-        "chloride-test": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
-          "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
-          "requires": {
-            "json-buffer": "2.0.11"
-          }
-        },
-        "class-list": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-          "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
-          "requires": {
-            "indexof": "0.0.1"
-          }
-        },
-        "ed2curve": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
-          "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "emoji-named-characters": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz",
-          "integrity": "sha1-zes20OZgAsS5178d+8Ohmft9QJs="
-        },
-        "emoji-server": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
-          "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
-          "requires": {
-            "emoji-named-characters": "1.0.2"
-          }
-        },
-        "html-element": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/html-element/-/html-element-1.3.0.tgz",
-          "integrity": "sha1-117LXa6HSx3mCgv4eUu9GYTQ8gk=",
-          "requires": {
-            "class-list": "0.1.1"
-          }
-        },
-        "hyperfile": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/hyperfile/-/hyperfile-1.1.1.tgz",
-          "integrity": "sha1-czvGxmj7miFgCMTzNlMfiU28efM=",
-          "requires": {
-            "hyperscript": "1.4.7"
-          }
-        },
-        "hyperprogress": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/hyperprogress/-/hyperprogress-0.1.1.tgz",
-          "integrity": "sha1-5TDGFjqisSg+rBkhkiJadi8Jw0Q="
-        },
-        "hyperscript": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-1.4.7.tgz",
-          "integrity": "sha1-HyPYgPhDbKrCW5GnrDl0e4mnJhg=",
-          "requires": {
-            "browser-split": "0.0.0",
-            "class-list": "0.1.1",
-            "html-element": "1.3.0"
-          }
-        },
-        "increment-buffer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
-          "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
-        },
-        "indexof": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "is-electron": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
-          "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
-        },
-        "json-buffer": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
-          "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
-        },
-        "libsodium": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-          "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
-        },
-        "libsodium-wrappers": {
-          "version": "0.2.12",
-          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-          "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
-          "requires": {
-            "libsodium": "0.2.12"
-          }
-        },
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-        },
-        "multiblob-http": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.2.0.tgz",
-          "integrity": "sha1-Ccgg7am4P2uYvOiEt1hGkm5r4VE=",
-          "requires": {
-            "pull-stream": "3.6.1",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "multiserver": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
-          "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.1",
-            "pull-ws": "3.2.10",
-            "secret-handshake": "1.1.11",
-            "separator-escape": "0.0.0",
-            "socks": "1.1.9",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "optional": true
-        },
-        "node-gyp-build": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-          "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
-          "optional": true
-        },
-        "options": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-        },
-        "pull-box-stream": {
-          "version": "1.0.13",
-          "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
-          "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
-          "requires": {
-            "chloride": "2.2.7",
-            "increment-buffer": "1.0.1",
-            "pull-reader": "1.2.9",
-            "pull-stream": "3.6.1",
-            "pull-through": "1.0.18",
-            "split-buffer": "1.0.0"
-          }
-        },
-        "pull-handshake": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-          "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-pair": "1.1.0",
-            "pull-pushable": "2.1.1",
-            "pull-reader": "1.2.9"
-          }
-        },
-        "pull-pair": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-          "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-        },
-        "pull-reader": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-          "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
-        },
-        "pull-through": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-          "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-          "requires": {
-            "looper": "3.0.0"
-          }
-        },
-        "pull-ws": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.2.10.tgz",
-          "integrity": "sha1-9yUsh/diqCdt18cR5zu8+T26xUk=",
-          "requires": {
-            "relative-url": "1.0.2",
-            "safe-buffer": "5.1.1",
-            "ws": "1.1.4"
-          }
-        },
-        "relative-url": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-          "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "secret-handshake": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.11.tgz",
-          "integrity": "sha1-I51hNnjx5cUPIj8mBfNkdc79Zl4=",
-          "requires": {
-            "chloride": "2.2.7",
-            "deep-equal": "1.0.1",
-            "pull-box-stream": "1.0.13",
-            "pull-handshake": "1.1.4",
-            "pull-stream": "3.6.1"
-          }
-        },
-        "separator-escape": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
-          "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
-        },
-        "sha.js": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
-          "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "smart-buffer": {
-          "version": "1.1.15",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-        },
-        "socks": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
-          "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
-          "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
-          }
-        },
-        "sodium-browserify": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-          "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
-          "requires": {
-            "libsodium-wrappers": "0.2.12",
-            "sha.js": "2.4.5",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "sodium-browserify-tweetnacl": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
-          "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
-          "requires": {
-            "chloride-test": "1.2.2",
-            "ed2curve": "0.1.4",
-            "sha.js": "2.4.8",
-            "tweetnacl": "0.14.5",
-            "tweetnacl-auth": "0.3.1"
-          },
-          "dependencies": {
-            "sha.js": {
-              "version": "2.4.8",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-              "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            }
-          }
-        },
-        "sodium-chloride": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
-          "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
-        },
-        "sodium-native": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.3.tgz",
-          "integrity": "sha512-FIeYaG5cc0YZjsAaWP/BCXDNO2xusbtDJbCbEvXrf6/6+dRo/8XCiEG0kwlRcR0wr56sgsZ327BId3ifFe2WYw==",
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0",
-            "node-gyp-build": "3.2.2"
-          }
-        },
-        "split-buffer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
-          "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
-        },
-        "ssb-sort": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-0.0.0.tgz",
-          "integrity": "sha1-OEwus/pIzEbF8R1Za/aGYZ+ol58=",
-          "requires": {
-            "ssb-ref": "2.7.1"
-          }
-        },
-        "stack": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz",
-          "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "tweetnacl-auth": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
-          "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "ultron": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-        },
-        "web-bootloader": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/web-bootloader/-/web-bootloader-0.1.2.tgz",
-          "integrity": "sha1-3hgiTOmGMz6piMOON26IGPKQJIY=",
-          "requires": {
-            "arraybuffer-base64": "1.0.0",
-            "binary-xhr": "0.0.2",
-            "hyperfile": "1.1.1",
-            "hyperprogress": "0.1.1"
-          }
-        },
-        "ws": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
-          "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-          "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
-          }
-        }
       }
+    },
+    "stack": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz",
+      "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
     },
     "statistics": {
       "version": "3.3.0",
@@ -8382,6 +3661,99 @@
         }
       }
     },
+    "streamview-links": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/streamview-links/-/streamview-links-2.1.1.tgz",
+      "integrity": "sha1-2bdaw7NaJfzn7ZME3JgR07o4P/E=",
+      "requires": {
+        "bytewise": "1.1.0",
+        "explain-error": "1.0.4",
+        "level": "1.7.0",
+        "ltgt": "2.2.0",
+        "map-filter-reduce": "3.0.3",
+        "pull-level": "2.0.3",
+        "pull-live": "1.0.1",
+        "pull-paramap": "1.2.2",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "3.6.1",
+        "pull-write": "1.1.4"
+      },
+      "dependencies": {
+        "map-filter-reduce": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.0.3.tgz",
+          "integrity": "sha1-ihC4bjRlut13YBqZV9velLmNYKo=",
+          "requires": {
+            "binary-search": "1.3.2",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "3.6.1",
+            "typewiselite": "1.0.0"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringify-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "requires": {
+        "character-entities-html4": "1.1.1",
+        "character-entities-legacy": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
     "tape": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.0.3.tgz",
@@ -8397,34 +3769,6 @@
         "through": "2.3.8"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "defined": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
-          "dev": true
-        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -8438,80 +3782,376 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "object-inspect": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
           "integrity": "sha1-qXiFtVPldetACevAm92psc0hl5o=",
           "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "resumer": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-          "dev": true,
-          "requires": {
-            "through": "2.3.8"
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
         }
       }
+    },
+    "tar-fs": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "requires": {
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+          "requires": {
+            "readable-stream": "2.3.3"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
+      "dev": true
+    },
+    "to-vfile": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
+      "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
+      "requires": {
+        "vfile": "1.4.0"
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-lines": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.0.tgz",
+      "integrity": "sha1-mSbQPt4Tuhj31CIiYx+wTHn/Jv4="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "tweetnacl-auth": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+      "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
       "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw=",
       "dev": true
+    },
+    "typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
+      "requires": {
+        "typewise-core": "1.2.0"
+      }
+    },
+    "typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
+    },
+    "typewiselite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
+    },
+    "uint48be": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz",
+      "integrity": "sha512-jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA=="
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "unherit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "requires": {
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "unified": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
+      "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
+      "requires": {
+        "attach-ware": "1.1.1",
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "unherit": "1.1.0",
+        "vfile": "1.4.0",
+        "ware": "1.3.0"
+      }
+    },
+    "unique-random": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
+      "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ=",
+      "dev": true
+    },
+    "unique-random-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
+      "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
+      "dev": true,
+      "requires": {
+        "unique-random": "1.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
+      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+    },
+    "unist-util-visit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.2.0.tgz",
+      "integrity": "sha512-lI+jyPlDztHZ2CJhUchcRMQ7MNc0yASgYFxwRTxs0EZ+9HbYFBLVGDJ2FchTBy+pra0O1LVEn0Wkgf19mDVDzw==",
+      "requires": {
+        "unist-util-is": "2.1.1"
+      }
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "vfile": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+      "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
+    },
+    "vfile-find-down": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
+      "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
+      "requires": {
+        "to-vfile": "1.0.0"
+      }
+    },
+    "vfile-find-up": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
+      "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
+      "requires": {
+        "to-vfile": "1.0.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
+      "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
+      "requires": {
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "repeat-string": "1.6.1",
+        "string-width": "1.0.2",
+        "text-table": "0.2.0",
+        "vfile-sort": "1.0.0"
+      }
+    },
+    "vfile-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz",
+      "integrity": "sha1-F+5JG6Q+iVG7IpE/z/MqfcTSNNQ="
+    },
+    "ware": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+      "requires": {
+        "wrap-fn": "0.1.5"
+      }
+    },
+    "web-bootloader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/web-bootloader/-/web-bootloader-0.1.2.tgz",
+      "integrity": "sha1-3hgiTOmGMz6piMOON26IGPKQJIY=",
+      "requires": {
+        "arraybuffer-base64": "1.0.0",
+        "binary-xhr": "0.0.2",
+        "hyperfile": "1.1.1",
+        "hyperprogress": "0.1.1"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wrap-fn": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+      "requires": {
+        "co": "3.1.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "zerr": {
       "version": "1.0.4",


### PR DESCRIPTION
It looks like this has fallen quite a bit behind, so it's hard to tell which packages should _actually_ be getting installed to get everything working. _Keeping_ this file up-to-date will depend on future PRs, but this is a one-time fix to bring us up-to-date.