### PR TITLE
add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "scuttlebot": "./bin.js"
   },
   "scripts": {
+    "start": "node bin server",
     "prepublishOnly": "npm ls && npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },


### PR DESCRIPTION
This way I can start scuttlebot instead of seeing an error when I habitually type `npm start` in the scuttlebot folder.