### PR TITLE
Added `id` flag for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sbot feed
 sbot log
 
 # stream all messages by one feed, ordered by sequence number
-sbot hist $FEED_ID
+sbot hist --id $FEED_ID
 ```
 ```js
 // In javascript:
@@ -86,7 +86,7 @@ ssbClient(function (err, sbot) {
 
   // stream all messages by one feed, ordered by sequence number
   pull(
-    sbot.createHistoryStream(feedId),
+    sbot.createHistoryStream({ id: < feedId > }),
     pull.collect(function (err, msgs) {
       // msgs[0].key == hash(msgs[0].value)
       // msgs[0].value...


### PR DESCRIPTION
When using `createHistoryStream` programmatically or `hist` from the CLI, it does not appear that passing the feedId as a string works. Passing in an object `{id: <feedId>}` or the `--id` flag using the CLI does though. Updated the readme for clarity. 

Currently running Ubuntu 16.+