### PR TITLE
Fix logging for level 'error'

### DIFF
--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -52,8 +52,11 @@ function formatter(id, level) {
 }
 
 module.exports = function logging (server, conf) {
-  var level = conf.logging && conf.logging.level ? conf.logging.level : DEFAULT_LEVEL
-  level = LOG_LEVELS.indexOf(level)
+  if (conf.logging && conf.logging.level) {
+    level = LOG_LEVELS.indexOf(conf.logging.level)
+  } else {
+    level = DEFAULT_LEVEL
+  }
 
   if (level === -1) {
     console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -52,7 +52,9 @@ function formatter(id, level) {
 }
 
 module.exports = function logging (server, conf) {
-  var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level) || DEFAULT_LEVEL
+  var level = conf.logging && conf.logging.level ? conf.logging.level : DEFAULT_LEVEL
+  level = LOG_LEVELS.indexOf(level)
+
   if (level === -1) {
     console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)
     console.log('Should be one of:', LOG_LEVELS.join(', '))


### PR DESCRIPTION
sbot would ignore the logging level when it was set to "error" because its index was tested for falsiness. Now we separate testing for the existence of a config log level and getting its `LOG_LEVELS` index. 
