### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 sudo: false
 node_js:
-  - '6.9.5'
+  - 8
+  - 6

--- a/test/invite.js
+++ b/test/invite.js
@@ -135,8 +135,8 @@ tape('test invite.accept doesnt follow if already followed', function (t) {
 })
 
 if (process.env.TRAVIS === 'true') {
-  console.warn('IPv6 is unsupported under Travis CI, test skipped');
-  skipIPv6 = true;
+  console.warn('IPv6 is unsupported under Travis CI, test skipped')
+  var skipIPv6 = true
 }
 
 tape('test invite.accept api with ipv6', { skip: skipIPv6 }, function (t) {

--- a/test/invite.js
+++ b/test/invite.js
@@ -134,7 +134,12 @@ tape('test invite.accept doesnt follow if already followed', function (t) {
   })
 })
 
-tape('test invite.accept api with ipv6', function (t) {
+if (process.env.TRAVIS === 'true') {
+  console.warn('IPv6 is unsupported under Travis CI, test skipped');
+  skipIPv6 = true;
+}
+
+tape('test invite.accept api with ipv6', { skip: skipIPv6 }, function (t) {
 
   var alice = createSbot({
     temp: 'test-invite-alice4', timeout: 100,


### PR DESCRIPTION
I've noticed that the Travis CI builds seem to be broken by the fact that [Travis doesn't support IPv6](https://docs.travis-ci.com/user/reference/precise/#Networking). This PR does three things:

- Disable IPv6 under Travis CI, emitting a simple warning instead
- Replace Node.js 6.9.5 test with Node.js 6.x for maintenance LTS testing
- Add Node.js 8 test with Node.js 8.x for active LTS testing

Please let me know if this could be done better, I'm open to any input. Thanks!

Resolves #447 

---

Note: it's still [possible](https://travis-ci.org/ssbc/scuttlebot/jobs/376165375) to fail, probably due to a race condition, but at least those jobs can be re-triggered with a reasonable probability of passing the next time. The goal of this PR is to make testing better, not perfect. :upside_down_face: 