### PR TITLE
bump ssb-query to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3110,7 +3110,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "options": {
@@ -4340,9 +4340,9 @@
       }
     },
     "ssb-query": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.0.1.tgz",
-      "integrity": "sha512-AjRY8S6gVTy9JeTpKY72GmWTgxAHmjCEIpIlQMcIQ13XVgQl61VOKB67KwwRRyIMJOh1y6Ruxm+9am8EuNBsBQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.1.0.tgz",
+      "integrity": "sha512-4QWvjSrSIon9qyhPHrqOeA/dp6NR7b11BtXKhJg/Di2r7/nBLGAj2RzUonfTfs3LlPHZdFWXowhhJREUAmUZug==",
       "requires": {
         "explain-error": "1.0.4",
         "flumeview-query": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ssb-keys": "^7.0.13",
     "ssb-links": "^3.0.2",
     "ssb-msgs": "~5.2.0",
-    "ssb-query": "^2.0.1",
+    "ssb-query": "^2.1.0",
     "ssb-ref": "^2.9.1",
     "ssb-ws": "^2.1.1",
     "statistics": "^3.0.0",


### PR DESCRIPTION
This is needed to bring scuttlebot up to speed with other applications in the the system in terms of vesion of index it's using for ssb-query. (I think this is only relevant for the `sbot server` command?)