### PR TITLE
bump flumelog-offset (performance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deep-equal": "^1.0.1",
     "explain-error": "^1.0.3",
     "flumedb": "^0.4.2",
-    "flumelog-offset": "^3.2.6",
+    "flumelog-offset": "^3.3.1",
     "flumeview-reduce": "^1.3.13",
     "has-network": "0.0.1",
     "ip": "^0.3.3",


### PR DESCRIPTION
Off the back of this PR on flumelog-offset https://github.com/flumedb/flumelog-offset/pull/11, thought this would be a good step 

I've not tested this in production yet

I wanted to commit the package-lock, but see you removed it @dominictarr . I've started a thread on ssb about this so it's referenceable %fLDEuIiCDBjljsO8DEF3K/G/DPnCs3BVQ8SC6c8FFYI=.sha256