### PR TITLE
Respect hops for incoming and outgoing connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ssb-client": "^4.5.7",
     "ssb-config": "^2.0.0",
     "ssb-ebt": "^5.1.4",
-    "ssb-friends": "^2.4.0",
+    "ssb-friends": "^3.1.3",
     "ssb-keys": "^7.0.13",
     "ssb-links": "^3.0.2",
     "ssb-msgs": "~5.2.0",


### PR DESCRIPTION
The idea with this pull request is that we shouldn't allow connections with any peers outside our hops. As it is now, sbot can connect to anyone but will only sync feeds within our hops. 

The biggest reason for this change is that right now anyone can connect to any peer and start requesting all feeds and thus map the whole network and use this for whatever reason they might have.