### PR TITLE
Add `addUnboxer` to be used by plugins

### DIFF
--- a/api.md
+++ b/api.md
@@ -339,3 +339,7 @@ an overview of how ssb is working.
 ## version: sync
 
 return the current version number of the running server
+
+## addUnboxer: sync
+
+add an unboxer to be used by the db

--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ var SSB = {
       createWriteStream        : ssb.createWriteStream,
       getVectorClock           : ssb.getVectorClock,
       getAtSequence            : ssb.getAtSequence,
+      addUnboxer               : ssb.addUnboxer,
     }
   }
 }


### PR DESCRIPTION
This gives plugins the ability to call [`addUnboxer()`](https://github.com/ssbc/secure-scuttlebutt/blob/beff8d063a20a1604ffe9110eb0d0f0911fc2e95/minimal.js#L187-L189) and add custom unboxer functions. This fits my use-case for blob-content posts, which use a [custom unboxer](https://github.com/ssbc/secure-scuttlebutt/blob/06937996465a317ac2c16ce234508900e1e69e56/minimal.js#L79-L106).

Relevant discussion on SSB: `%rciFuVmIAi6WxamBNcF+EYSnJtngAbHwxxmtudsz3v4=.sha256`