### PR TITLE
Add map function

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,25 +47,25 @@ var SSB = {
     if(!opts.path)
       throw new Error('opts.path *must* be provided, or use opts.temp=name to create a test instance')
 
-    var mappers = []
-    var mapChain = (val, cb) => {
-      let idx = 0
-      const chainNext = (err, val) => {
-        if (err) cb(err)
-        if (idx <= mappers.length - 1) {
-          idx += 1
-          mappers[idx - 1](val, chainNext)
-        } else {
+    var maps = []
+    var chainMaps = (val, cb) => {
+      let idx = -1 // haven't entered the chain yet
+      const next = (err, val) => {
+        idx += 1
+        if (err || idx === maps.length)
           cb(err, val)
-        }
+        else
+          maps[idx](val, next)
       }
-      chainNext(null, val)
+      next(null, val)
     }
 
     if(!opts.map)
       opts.map = (val, cb) => {
-        if (!mappers.length) return cb(null, val)
-        mapChain(val, cb)
+        if (!maps)
+          cb(null, val)
+        else
+          chainMaps(val, cb)
       }
 
     // main interface
@@ -157,7 +157,7 @@ var SSB = {
       getAtSequence            : ssb.getAtSequence,
       addUnboxer               : ssb.addUnboxer,
       addMap                   : function(fn) {
-        mappers.push(fn)
+        maps.push(fn)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pull-stringify": "~1.2.2",
     "rimraf": "^2.4.2",
     "secret-stack": "^4.2.1",
-    "secure-scuttlebutt": "^18.3.1",
+    "secure-scuttlebutt": "git+https://github.com/ssbc/secure-scuttlebutt.git#add-map-option",
     "ssb-blobs": "^1.1.4",
     "ssb-client": "^4.5.7",
     "ssb-config": "^2.3.0",


### PR DESCRIPTION
This builds on https://github.com/flumedb/flumedb/pull/19 and tentatively https://github.com/ssbc/secure-scuttlebutt/pull/222 to expose a map function to Scuttlebot plugins. Usage currently looks like:

```js
.use(function (ssk, config) {
  ssk.addMap((val, cb) => {
    val.value.mapWorks = true
    cb(null, val)
  })
})
```

```console
$ ./bin.js get '%59UufAGSLgEUQWsvdZEHSIGw/x2ezxY5jczavjpKFZ8=.sha256'
{
  "previous": "%2+uc1az8Xk9NGV4xMSnaMyXyq2eLeBWGzQlcpT/emac=.sha256",
  "sequence": 4925,
  "author": "@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519",
  "timestamp": 1537379262052,
  "hash": "sha256",
  "content": {
    "type": "blob",
    "blob": "&sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n/OJGSC1U=.sha256"
  },
  "signature": "j8/lzTjN/FJYEMHyaJqFdJj5tyDPR9D1R+l8foO3XE7sZTfOVZrLM7zXsggipXEXtWo/WYgylMfE3Hkhie7IDA==.sig.ed25519",
  "mapWorks": true
}
```

Each map function added with `addMap()` is chained, so a later map could check for `val.value.mapWorks` and have no trouble accessing it. I'm under the impression that **plugin order matters**, but I'm not sure whether that's already a Scuttlebot plugin constraint.

I'm currently looking for feedback on:

- whether `secure-scuttlebutt/create` could ever start before all plugins are loaded (?)
- the best way to implement the `chainMaps` function (or similar)
  - this is semi-trivial with promises, but I'm under the impression that promises aren't the preference
  - the current implementation is just the first thing I got working, it could use some polish/refactoring
- any suggestions, improvements, criticisms, etc., or thoughts on how to do this differently

Thanks for checking out this PR!