### PR TITLE
Replace deprecated buffer constructors with `Buffer.from()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var SSB = {
     mkdirp.sync(dbPath)
 
     if(!opts.keys)
-      opts.keys = ssbKeys.generate('ed25519', opts.seed && new Buffer(opts.seed, 'base64'))
+      opts.keys = ssbKeys.generate('ed25519', opts.seed && Buffer.from(opts.seed, 'base64'))
 
     if(!opts.path)
       throw new Error('opts.path *must* be provided, or use opts.temp=name to create a test instance')

--- a/lib/ssb-cap.js
+++ b/lib/ssb-cap.js
@@ -2,7 +2,7 @@
 //this will be updated whenever breaking changes are made.
 //(see secret-handshake paper for a full explaination)
 module.exports =
-  new Buffer('1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=', 'base64')
+  Buffer.from('1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=', 'base64')
 
 //there is nothing special about this value.
 //I generated it in the node repl with:

--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -133,7 +133,7 @@ module.exports = {
                   var name = path.basename(pluginName)
                   config.plugins[name] = true
                   writePluginConfig(name, true)
-                  p.push(new Buffer('"'+pluginName+'" has been installed. Restart Scuttlebot server to enable the plugin.\n', 'utf-8'))
+                  p.push(Buffer.from('"'+pluginName+'" has been installed. Restart Scuttlebot server to enable the plugin.\n', 'utf-8'))
                   p.end()
                 }
               )
@@ -141,7 +141,7 @@ module.exports = {
               p.end(new Error('"'+pluginName+'" failed to install. See log output above.'))
           })
         return cat([
-          pull.values([new Buffer('Installing "'+pluginName+'"...\n', 'utf-8')]),
+          pull.values([Buffer.from('Installing "'+pluginName+'"...\n', 'utf-8')]),
           many([toPull(child.stdout), toPull(child.stderr)]),
           p
         ])
@@ -156,7 +156,7 @@ module.exports = {
         rimraf(modulePath, function (err) {
           if (!err) {
             writePluginConfig(pluginName, false)
-            p.push(new Buffer('"'+pluginName+'" has been uninstalled. Restart Scuttlebot server to disable the plugin.\n', 'utf-8'))
+            p.push(Buffer.from('"'+pluginName+'" has been uninstalled. Restart Scuttlebot server to disable the plugin.\n', 'utf-8'))
             p.end()
           } else
             p.end(err)


### PR DESCRIPTION
I've been seeing this deprecation notice for a while and wanted to resolve it:

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Background: [Porting to the Buffer.from()/Buffer.alloc() API](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1)