### PR TITLE
gossip uses multiserver addresses locally

### DIFF
--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -215,7 +215,7 @@ module.exports = {
       }, 'string|object'),
 
       disconnect: valid.async(function (addr, cb) {
-        var peer = this.get(addr)
+        var peer = gossip.get(addr)
 
         peer.state = 'disconnecting'
         peer.stateChange = Date.now()

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -282,7 +282,7 @@ module.exports = {
         //between 10 seconds and 30 minutes, default 5 min
         timeout = Math.max(10e3, Math.min(timeout, 30*60e3))
         return ping({timeout: timeout})
-1      },
+      },
       reconnect: function () {
         for(var id in server.peers)
           if(id !== server.id) //don't disconnect local client

--- a/plugins/gossip/index.js
+++ b/plugins/gossip/index.js
@@ -176,6 +176,8 @@ module.exports = {
 //        })
       },
       connect: valid.async(function (addr, cb) {
+        if(ref.isFeed(addr))
+          addr = gossip.get(addr)
         server.emit('log:info', ['SBOT', stringify(addr), 'CONNECTING'])
         if(!ref.isAddress(addr.address))
           addr = ref.parseAddress(addr)

--- a/plugins/gossip/init.js
+++ b/plugins/gossip/init.js
@@ -12,21 +12,18 @@ module.exports = function (gossip, config, server) {
   .forEach(function (addr) { gossip.add(addr, 'seed') })
 
   // populate peertable with pub announcements on the feed
-  pull(
-    server.messagesByType({
-      type: 'pub', live: true, keys: false
-    }),
-    pull.drain(function (msg) {
-      if(msg.sync) return
-      if(!msg.content.address) return
-      if(ref.isAddress(msg.content.address))
-        gossip.add(msg.content.address, 'pub')
-    })
-  )
-
-  // populate peertable with announcements on the LAN multicast
-  server.on('local', function (_peer) {
-    gossip.add(_peer, 'local')
-  })
+  if(!config.gossip || config.gossip.pub !== false)
+    pull(
+      server.messagesByType({
+        type: 'pub', live: true, keys: false
+      }),
+      pull.drain(function (msg) {
+        if(msg.sync) return
+        if(!msg.content.address) return
+        if(ref.isAddress(msg.content.address))
+          gossip.add(msg.content.address, 'pub')
+      })
+    )
 
 }
+

--- a/plugins/local.js
+++ b/plugins/local.js
@@ -56,6 +56,8 @@ module.exports = {
       if (peer && peer.key !== sbot.id) {
         addrs[peer.key] = peer
         lastSeen[peer.key] = Date.now()
+        //note: add the raw data, not the parsed data.
+        //so we still have the whole address, including protocol (eg, websockets)
         sbot.gossip.add(data, 'local')
       }
     })
@@ -83,4 +85,5 @@ module.exports = {
     }, 1000)
   }
 }
+
 

--- a/test/gossip.js
+++ b/test/gossip.js
@@ -79,10 +79,8 @@ tape('ignore invalid pub messages', function (t) {
 })
 
 tape('cleanup', function (t) {
-  sbot.close(true, function () {})
+  sbot.close()
   t.end()
-  //I don't know why this is necessary
-  //because the other tests exit fine.
-  process.exit(0)
 })
+
 

--- a/test/gossip.js
+++ b/test/gossip.js
@@ -20,29 +20,35 @@ var sbot = createSbot({
   timeout: 1000
 })
 
+var localhost = {
+  host: 'localhost', port: 8888,
+  key: ssbKeys.generate().id
+}
+var ip = {
+  host: '182.23.49.132', port: 8881,
+  key: ssbKeys.generate().id
+}
+var example = {
+  host: 'example.com', port: 8889,
+  key: ssbKeys.generate().id
+}
+
+var peers = JSON.parse(JSON.stringify([localhost, ip, example]))
+var peers2 = peers.map(function (e) {
+  var k = ssbKeys.generate().id
+  return 'net:'+e.host+':'+(e.port+1)+'~shs:'+k.substring(1, k.indexOf('.')) 
+})
+
 tape('gossip: add and get peers', function (t) {
 
   t.ok(isArray(sbot.gossip.peers()))
 
-  var localhost = {
-    host: 'localhost', port: 8888,
-    key: ssbKeys.generate().id
-  }
-  var ip = {
-    host: '182.23.49.132', port: 8881,
-    key: ssbKeys.generate().id
-  }
-  var example = {
-    host: 'example.com', port: 8889,
-    key: ssbKeys.generate().id
-  }
 
-  var peers = JSON.parse(JSON.stringify([localhost, ip, example]))
+  //clone input, because gossip mutates it.
   sbot.gossip.add(localhost)
   sbot.gossip.add(ip)
   sbot.gossip.add(example)
 
-  console.log(sbot.gossip.peers())
   t.deepEqual(
     sbot.gossip.peers().map(function (e) {
       console.log(e, ref.parseAddress(e.address))
@@ -53,6 +59,20 @@ tape('gossip: add and get peers', function (t) {
 
   t.end()
 
+})
+
+tape('gossip: add string address', function (t) {
+  peers2.forEach(function (e) {
+    sbot.gossip.add(e, 'manual')
+  })
+  console.log(sbot.gossip.peers())
+  t.deepEqual(
+    sbot.gossip.peers().map(function (e) {
+      return e.address
+    }).slice(3),
+    peers2
+  )
+  t.end()
 })
 
 tape('gossip: errors on invalid peers', function (t) {
@@ -90,6 +110,9 @@ tape('cleanup', function (t) {
   sbot.close()
   t.end()
 })
+
+
+
 
 
 

--- a/test/gossip.js
+++ b/test/gossip.js
@@ -57,6 +57,10 @@ tape('gossip: add and get peers', function (t) {
     peers
   )
 
+  sbot.gossip.peers().forEach(function (e) {
+    t.equal(sbot.gossip.get(e.key).key, e.key)
+  })
+
   t.end()
 
 })
@@ -110,11 +114,4 @@ tape('cleanup', function (t) {
   sbot.close()
   t.end()
 })
-
-
-
-
-
-
-
 

--- a/test/gossip.js
+++ b/test/gossip.js
@@ -4,7 +4,7 @@ var deepEqual = require('deep-equal')
 var tape      = require('tape')
 var pull      = require('pull-stream')
 var ssbKeys   = require('ssb-keys')
-
+var ref       = require('ssb-ref')
 var u = require('./util')
 var isArray = Array.isArray
 
@@ -37,11 +37,19 @@ tape('gossip: add and get peers', function (t) {
     key: ssbKeys.generate().id
   }
 
+  var peers = JSON.parse(JSON.stringify([localhost, ip, example]))
   sbot.gossip.add(localhost)
   sbot.gossip.add(ip)
   sbot.gossip.add(example)
 
-  t.deepEqual(sbot.gossip.peers(), [localhost, ip, example])
+  console.log(sbot.gossip.peers())
+  t.deepEqual(
+    sbot.gossip.peers().map(function (e) {
+      console.log(e, ref.parseAddress(e.address))
+      return ref.parseAddress(e.address)
+    }),
+    peers
+  )
 
   t.end()
 
@@ -82,5 +90,8 @@ tape('cleanup', function (t) {
   sbot.close()
   t.end()
 })
+
+
+
 
 


### PR DESCRIPTION
I want gossip to use multiserver addresses locally, so that you can for example, gossip over websockets, or webrtc, or [tunnel](https://github.com/dominictarr/ssb-tunnel) to a peer. The code is still ugly, but I just fixed up the minimum amount to get this in.

Also I added an option to disable replication to `pub` advertisements. These were an ugly hack that we made back in the day, that I'd like to remove. (switching to user invites should achieve that) in particular, they are a problem because it's hard to tell if a pub is really still at that address - and since you announce someone else's address, which is insufficiently consentful.