### PR TITLE
refactor networking plugins, don't use by default, and use ssb-ws instead of inlined ws plugin

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -39,6 +39,9 @@ if (argv[0] == 'server') {
   // import sbot and start the server
 
   var createSbot = require('./')
+    .use(require('./plugins/onion'))
+    .use(require('./plugins/unix-socket'))
+    .use(require('./plugins/no-auth'))
     .use(require('./plugins/plugins'))
     .use(require('./plugins/master'))
     .use(require('./plugins/gossip'))
@@ -150,7 +153,4 @@ if (argv[0] == 'server') {
     muxrpcli(argv, manifest, rpc, config.verbose)
   })
 }
-
-
-
 

--- a/index.js
+++ b/index.js
@@ -181,19 +181,6 @@ function createSbot() {
       })
     })
     .use(function (ssk, config) {
-      var WS = require('multiserver/plugins/ws')
-
-      ssk.multiserver.transport({
-        name: 'ws',
-        create: function (conf) {
-          if (!conf.port)
-            conf.port = 1024+(~~(Math.random()*(65536-1024)))
-
-          return WS(conf)
-        }
-      })
-    })
-    .use(function (ssk, config) {
       var Unix = require('multiserver/plugins/unix-socket')
       ssk.multiserver.transport({
         name: 'unix',
@@ -219,5 +206,6 @@ function createSbot() {
 }
 module.exports = createSbot()
 module.exports.createSbot = createSbot
+
 
 

--- a/index.js
+++ b/index.js
@@ -170,15 +170,9 @@ function createSbot() {
     appKey: require('./lib/ssb-cap')
   })
     .use(SSB)
-    .use(require('./plugins/onion'))
-    .use(require('./plugins/unix-socket'))
-    .use(require('./plugins/no-auth'))
 }
 module.exports = createSbot()
 module.exports.createSbot = createSbot
-
-
-
 
 
 

--- a/index.js
+++ b/index.js
@@ -170,42 +170,17 @@ function createSbot() {
     appKey: require('./lib/ssb-cap')
   })
     .use(SSB)
-    .use(function (ssk, config) {
-      var Onion = require('multiserver/plugins/onion')
-
-      ssk.multiserver.transport({
-        name: 'onion',
-        create: function (conf) {
-          return Onion(conf)
-        }
-      })
-    })
-    .use(function (ssk, config) {
-      var Unix = require('multiserver/plugins/unix-socket')
-      ssk.multiserver.transport({
-        name: 'unix',
-        create: function (conf) {
-          return Unix(config)
-        }
-      })
-    })
-    .use(function (ssk, config) {
-      var Noauth = require('multiserver/plugins/noauth')
-
-      ssk.multiserver.transform({
-        name: 'noauth',
-        create: function () {
-          return Noauth({
-            keys: {
-              publicKey: Buffer.from(config.keys.public, 'base64')
-            }
-          })
-        }
-      })
-    })
+    .use(require('./plugins/onion'))
+    .use(require('./plugins/unix-socket'))
+    .use(require('./plugins/no-auth'))
 }
 module.exports = createSbot()
 module.exports.createSbot = createSbot
+
+
+
+
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ssb-msgs": "~5.2.0",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.12.0",
-    "ssb-ws": "^2.1.1",
+    "ssb-ws": "^3.0.0",
     "statistics": "^3.0.0",
     "stream-to-pull-stream": "^1.6.10",
     "zerr": "^1.0.0"

--- a/plugins/no-auth.js
+++ b/plugins/no-auth.js
@@ -1,0 +1,17 @@
+
+exports.name = 'no-auth'
+exports.version = '1.0.0'
+exports.init = function (ssk, config) {
+  var Noauth = require('multiserver/plugins/noauth')
+
+  ssk.multiserver.transform({
+    name: 'noauth',
+    create: function () {
+      return Noauth({
+        keys: {
+          publicKey: Buffer.from(config.keys.public, 'base64')
+        }
+      })
+    }
+  })
+}

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -1,0 +1,12 @@
+exports.name = 'onion'
+exports.version = '1.0.0'
+exports.init = function (ssk, config) {
+  var Onion = require('multiserver/plugins/onion')
+
+  ssk.multiserver.transport({
+    name: 'onion',
+    create: function (conf) {
+      return Onion(conf)
+    }
+  })
+}

--- a/plugins/unix-socket.js
+++ b/plugins/unix-socket.js
@@ -1,0 +1,12 @@
+
+exports.name = 'unix-socket'
+exports.version = '1.0.0'
+exports.init = function (ssk, config) {
+  var Unix = require('multiserver/plugins/unix-socket')
+  ssk.multiserver.transport({
+    name: 'unix',
+    create: function (conf) {
+      return Unix(config)
+    }
+  })
+}


### PR DESCRIPTION
I started out just wanting to get the old ssb-ws plugin updated, and working with sbot again, but in 12 sbot added it's own ws server, so I needed to move that... and then I also thought that those other plugins should be moved away.

I'm seriously thinking that secret-stack shouldn't even load a networking plugin (or shs) and that should be loaded by sbot user...

I've also been thinking that now that it's so easy to add more protocols, and they are well-integrated, we need a good way to add protocols to ssb-client... it would be nice if ssb-client also had a `.use(plugin)` method - but it just didn't create a server? something like this is probably important to get ssb on the browser