### PR TITLE
WIP: Add hacky "test" for new meta code

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,11 +171,22 @@ function createSbot() {
     appKey: require('./lib/ssb-cap')
   })
     .use(SSB)
+    .use(api => {
+      api.addMap((msg, cb) => {
+        if (!msg.value.meta) {
+          msg.value.meta = {}
+        }
+
+        msg.value.meta.random = 42
+        msg.value.meta.foo = 'bar'
+
+        cb(null, msg)
+      })
+    })
 }
+
 module.exports = createSbot()
 module.exports.createSbot = createSbot
-
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pull-stringify": "~1.2.2",
     "rimraf": "^2.4.2",
     "secret-stack": "^4.2.1",
-    "secure-scuttlebutt": "^18.5.0",
+    "secure-scuttlebutt": "git+https://github.com/ssbc/secure-scuttlebutt.git#map-unboxer-meta",
     "ssb-blobs": "^1.1.4",
     "ssb-client": "^4.5.7",
     "ssb-config": "^2.3.0",


### PR DESCRIPTION
This adds and `addMap()` to test https://github.com/ssbc/secure-scuttlebutt/pull/228/ and see what breaks. Currently everything seems to be working great. It's clear to me that this test shouldn't be in index.js, but is there somewhere else it should be placed? I'm hesitant to put it in its own isolated file because it affects the output of *all* tests, but I suppose maybe I could just add it as a test-only plugin? Not sure what the right call is here.