### PR TITLE
Delete .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-


### PR DESCRIPTION
I don't think this file does anything. See [the NPM documentation](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package):

> Additionally, everything in `node_modules` is ignored, except for bundled dependencies. npm automatically handles this for you, so don't bother adding `node_modules` to `.npmignore`.