### PR TITLE
Add .npmrc to disable package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Resolves #534 

I've pushed an `add-npmrc` branch for *every* SSBC repo that follows the "no package-lock.json" tendency -- should I open pull requests for each of them, or should I just merge to `master` and push? I've done the same with `add-gitignore` for NPM package repos that don't have `node_modules` being ignored by git.