### PR TITLE
support multiple scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,4 @@ node_modules
 sbot.js
 .ssbrc
 *.log
-
-
-
+coverage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "minimist": "^1.1.3",
     "mkdirp": "~0.5.0",
     "multiblob": "^1.13.0",
-    "multiserver": "^1.13.4",
+    "multiserver": "^2.0.0",
     "multiserver-address": "^1.0.1",
     "muxrpc-validation": "^2.0.0",
     "muxrpcli": "^1.0.0",
@@ -53,7 +53,7 @@
     "ssb-links": "^3.0.2",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.3",
-    "ssb-ws": "^3.0.0",
+    "ssb-ws": "^3.0.1",
     "statistics": "^3.0.0",
     "stream-to-pull-stream": "^1.6.10",
     "zerr": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ssb-links": "^3.0.2",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.3",
-    "ssb-ws": "^3.0.1",
+    "ssb-ws": "^3.0.2",
     "statistics": "^3.0.0",
     "stream-to-pull-stream": "^1.6.10",
     "zerr": "^1.0.0"

--- a/plugins/local.js
+++ b/plugins/local.js
@@ -72,18 +72,21 @@ module.exports = {
       return _status
     })
 
-    // broadcast self
-    setInterval(function () {
-      if(config.gossip && config.gossip.local === false)
-        return
-      // TODO: sign beacons, so that receipient can be confidant
-      // that is really your id.
-      // (which means they can update their peer table)
-      // Oh if this includes your local address,
-      // then it becomes unforgeable.
-      local.write(sbot.getAddress('private'))
-    }, 1000)
+    setImmediate(function () {
+      // broadcast self
+      var int = setInterval(function () {
+        if(config.gossip && config.gossip.local === false)
+          return
+        // TODO: sign beacons, so that receipient can be confidant
+        // that is really your id.
+        // (which means they can update their peer table)
+        // Oh if this includes your local address,
+        // then it becomes unforgeable.
+        var addr = sbot.getAddress('private') || sbot.getAddress('local')
+        if(addr) local.write(addr)
+      }, 1000)
+      if(int.unref) int.unref()
+    })
   }
 }
-
 

--- a/test/bin.js
+++ b/test/bin.js
@@ -225,10 +225,17 @@ test('sbot should have websockets and http server by default', function(t) {
 
 test('sbot client should work without options', function(t) {
   var path = '/tmp/sbot_binjstest_' + Date.now()
+  mkdirp.sync(path)
+  fs.writeFileSync(path+'/config', 
+    JSON.stringify({
+      port: 43293, ws: { port: 43294 }
+    })
+  )
   var caps = crypto.randomBytes(32).toString('base64')
   var end = sbot(t, [
     'server',
     '--path', path,
+    '--config', path+'/config',
     '--caps.shs', caps
   ])
 
@@ -238,6 +245,7 @@ test('sbot client should work without options', function(t) {
       'getAddress',
       'device',
       '--path', path,
+      '--config', path+'/config',
       '--caps.shs', caps
     ].join(' '), {
       env: Object.assign({}, process.env, {ssb_appname: 'test'})
@@ -253,4 +261,5 @@ test('sbot client should work without options', function(t) {
     end()
   })
 })
+
 

--- a/test/bin.js
+++ b/test/bin.js
@@ -190,6 +190,7 @@ test('sbot should have websockets and http server by default', function(t) {
     exec([
       join(__dirname, '../bin.js'),
       'getAddress',
+      'device',
       '--',
       '--host=127.0.0.1',
       '--port=9001',


### PR DESCRIPTION
mainly this is updating the invite plugin, so that if allowPrivate is used, it uses the local scope instead of public.

depends on: 
* https://github.com/ssbc/multiserver/pull/32
* https://github.com/ssbc/ssb-config/pull/25
* https://github.com/ssbc/secret-stack/pull/31
* and ssb-ws@3.0.2 @regular I couldn't quite figure out what was going on with the multiple servers thing on ssb-ws@4

all the tests are now passing again, and `getAddress <scope>` returns something sensible.