### PR TITLE
Remove ssb-links

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -57,6 +57,13 @@ if (argv[0] == 'server') {
   // add third-party plugins
   require('./plugins/plugins').loadUserPlugins(createSbot, config)
 
+  if (argv[1] != '--disable-ssb-links') {
+    if (!createSbot.plugins.find(p => p.name == 'links2')) {
+      console.log("WARNING-DEPRECATION: ssb-links not installed as a plugin. If you are using git-ssb, ssb-npm or patchfoo please consider installing it")
+      createSbot.use(require('ssb-links'))
+    }
+  }
+
   // start server
 
   config.keys = keys

--- a/bin.js
+++ b/bin.js
@@ -52,7 +52,6 @@ if (argv[0] == 'server') {
     .use(require('./plugins/local'))
     .use(require('./plugins/logging'))
     .use(require('ssb-query'))
-    .use(require('ssb-links'))
     .use(require('ssb-ws'))
     .use(require('ssb-ebt'))
   // add third-party plugins

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ssb-ebt": "^5.1.4",
     "ssb-friends": "^3.1.3",
     "ssb-keys": "^7.1.1",
-    "ssb-links": "^3.0.2",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.3",
     "ssb-ws": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ssb-ebt": "^5.1.4",
     "ssb-friends": "^3.1.3",
     "ssb-keys": "^7.1.1",
+    "ssb-links": "^3.0.2",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.3",
     "ssb-ws": "^3.0.1",


### PR DESCRIPTION
I was looking at the various flume indexes and bumped into the links and links2. While links is used internally by secure-scuttlebutt for things like messagesByType, links2 doesn't really seem to be used at all. Maybe it was used for some of the old functions that was removed once?

Doing a full search on github reveals that it is exposed in ssb-ws [here](https://github.com/ssbc/ssb-ws/blob/master/index.js#L28) and used in patchfoo. But patchfoo installs it as a plugin, so that shouldn't be any problem. I then checked mvd at it appears only to be referenced in [manifest](https://github.com/evbogue/mvd/blob/392e50fcc67f4ad4b873fc95b096e3018404f255/manifest.json#L70) but never used. @evbogue can you confirm?

Ping @regular are you using that api for anything?

The thing is that this index was the biggest of all on my machine. 233M. So it would be really nice not having to maintain that index if its not really used anymore. And if it is, then people should include it themselves. Also scuttle-shell includes this [exactly](https://github.com/ssbc/scuttle-shell/blob/master/server.js#L59) for patch-foo, so when people start using it this shouldn't be a problem. On the other hand it would probably be a good idea to see if patchfoo could use another api as to remove the indexing overhead in there. But that is totally unrelated to this PR imo, just a friendly reminder :)