### PR TITLE
Don't nuke config if its not valid json.

### DIFF
--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -60,11 +60,8 @@ module.exports = {
     // write the plugin config to ~/.ssb/config
     function writePluginConfig (pluginName, value) {
       var cfgPath = path.join(config.path, 'config')
-      var existingConfig = {}
-      
       // load ~/.ssb/config
-      try { existingConfig = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) }
-      catch (e) {}
+      var existingConfig = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'))
 
       // update the plugins config
       existingConfig.plugins = existingConfig.plugins || {}


### PR DESCRIPTION
The problem is that earlier if one had invalid json it would just end up with an empty dict and write the plugin to that, thus nuking your carefully handwritten config. This bails instead and actually shows what is "wrong" with the file.