### PR TITLE
Fix config file read

### DIFF
--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -61,14 +61,28 @@ module.exports = {
     function writePluginConfig (pluginName, value) {
       var cfgPath = path.join(config.path, 'config')
       // load ~/.ssb/config
-      var existingConfig = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'))
+      let existingConfig
+      fs.readFile(cfgPath, 'utf-8', (err, data) => {
+        if (err) {
+          if (err.code === 'ENOENT') {
+            // only catch "file not found"
+            existingConfig = {}
+          } else {
+            throw err
+          }
+        } else {
+          existingConfig = JSON.parse(data)
+        }
 
-      // update the plugins config
-      existingConfig.plugins = existingConfig.plugins || {}
-      existingConfig.plugins[pluginName] = value
 
-      // write to disc
-      fs.writeFileSync(cfgPath, JSON.stringify(existingConfig, null, 2), 'utf-8')
+        // update the plugins config
+        existingConfig.plugins = existingConfig.plugins || {}
+        existingConfig.plugins[pluginName] = value
+
+        // write to disc
+        fs.writeFileSync(cfgPath, JSON.stringify(existingConfig, null, 2), 'utf-8')
+      })
+
     }
 
     return {


### PR DESCRIPTION
This was recently refactored to prevent the server from overwriting invalid config files, but had a bug where it would crash when the config file was missing. This commit aims to be the best of both worlds, where we can continue safely on missing config files but crash loudly when the config file has the wrong permissions or is invalid JSON.

Resolves #584 